### PR TITLE
docs: 同步中文 README，移除构建说明 + 添加故障排查

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,50 +278,13 @@ readlink /etc/opentenbase/current
 
 ## Deployment Options
 
-OpenTenBase supports two deployment approaches:
+| Aspect | Pre-built Packages |
+|--------|-------------------|
+| **Deploy time** | ~2 minutes |
+| **Image size** | ~500 MB |
+| **Best for** | Production, quick testing, evaluation |
 
-| Aspect | Pre-built Packages | Source Build |
-|--------|-------------------|--------------|
-| **Deploy time** | ~2 minutes | 30-60 minutes (first time) |
-| **Customization** | Not supported | Full control (debug, cassert, etc.) |
-| **Best for** | Production, quick testing | Development, learning, contributing |
-| **Image size** | ~500 MB | ~2 GB |
-
-**Recommendation**: Use pre-built packages for production and quick evaluation. Use source builds for development, debugging, and contributing to the project. See [source-build-guide.md](docs/source-build-guide.md) for detailed source build instructions.
-
----
-
-## Build from Source
-
-### Docker Build (Recommended)
-
-```bash
-git clone https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages.git
-cd OpenTenBase-Packages
-
-# Build for all distributions
-./scripts/build-multi.sh --all
-
-# Build for Ubuntu 24.04 only
-./scripts/build-multi.sh -d ubuntu -v 24.04
-
-# Build RPM only
-./scripts/build-multi.sh --rpm
-```
-
-### Local Build
-
-```bash
-# Install build dependencies
-sudo apt install -y debhelper-compat bison flex perl libreadline-dev \
-    zlib1g-dev libssl-dev libxml2-dev libldap2-dev uuid-dev pkg-config
-
-# Build DEB packages
-./scripts/build-deb.sh
-
-# Build RPM packages
-./scripts/build-rpm.sh
-```
+> For developers who want to build from source, see [source-build-guide.md](docs/source-build-guide.md).
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -274,50 +274,13 @@ readlink /etc/opentenbase/current
 
 ## 部署方式
 
-OpenTenBase 支持两种部署方式：
+| 方面 | 预编译包 |
+|------|---------|
+| **部署时间** | ~2 分钟 |
+| **镜像大小** | ~500 MB |
+| **适用场景** | 生产环境、快速测试、评估 |
 
-| 方面 | 预编译包 | 源码编译 |
-|------|---------|---------|
-| **部署时间** | ~2 分钟 | 30-60 分钟（首次） |
-| **自定义** | 不支持 | 完全控制（调试、cassert 等） |
-| **适用场景** | 生产环境、快速测试 | 开发、学习、贡献 |
-| **镜像大小** | ~500 MB | ~2 GB |
-
-**建议**：生产环境和快速体验使用预编译包，开发调试和贡献代码使用源码编译。详见 [source-build-guide.md](docs/source-build-guide.md)。
-
----
-
-## 从源码构建
-
-### 使用 Docker 构建（推荐）
-
-```bash
-git clone https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages.git
-cd OpenTenBase-Packages
-
-# 构建所有发行版
-./scripts/build-multi.sh --all
-
-# 仅构建 Ubuntu 24.04
-./scripts/build-multi.sh -d ubuntu -v 24.04
-
-# 仅构建 RPM
-./scripts/build-multi.sh --rpm
-```
-
-### 本地构建
-
-```bash
-# 安装构建依赖
-sudo apt install -y debhelper-compat bison flex perl libreadline-dev \
-    zlib1g-dev libssl-dev libxml2-dev libldap2-dev uuid-dev pkg-config
-
-# 构建 DEB 包
-./scripts/build-deb.sh
-
-# 构建 RPM 包
-./scripts/build-rpm.sh
-```
+> 如需从源码构建，请参考 [source-build-guide.md](docs/source-build-guide.md)。
 
 ---
 
@@ -471,6 +434,71 @@ gh workflow run stress-test.yml
 | 限制 | 说明 |
 |------|------|
 | 同机多集群 | 由于端口冲突，不支持同一台机器运行多套集群；每台机器运行一套集群（GTM + 协调器 + 数据节点） |
+
+---
+
+## 故障排查
+
+### `Unable to locate package opentenbase`
+
+**原因**：APT 源未更新或仓库未签名导致 `apt update` 跳过了 OpenTenBase 源。
+
+**解决**：
+
+```bash
+# 1. 重新运行安装脚本（会自动检测签名状态）
+curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-apt.sh | sudo bash
+
+# 2. 手动更新
+sudo apt update
+sudo apt install opentenbase
+```
+
+### `The repository '... noble Release' is not signed`
+
+**原因**：仓库缺少 GPG 签名文件（`Release.gpg` / `InRelease`）。脚本会自动回退到 `trusted=yes` 模式，无需手动处理。如果仍然报错，重新运行安装脚本即可。
+
+### `GPG 密钥下载失败`
+
+**原因**：网络环境无法访问 Cloudflare CDN 或 GitHub Pages。
+
+**解决**：
+
+```bash
+# 方法1：重试（网络波动可能导致临时失败）
+curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-apt.sh | sudo bash
+
+# 方法2：手动下载密钥并配置
+curl -sSL https://repo.blackevil217.com/apt/gpg-key.asc -o /tmp/key.asc
+sudo gpg --batch --dearmor -o /usr/share/keyrings/opentenbase-archive-keyring.gpg < /tmp/key.asc
+
+# 方法3：配置环境变量使用代理
+export https_proxy=http://your-proxy:port
+curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-apt.sh | sudo bash
+```
+
+### `apt-get update` 报其他仓库 404 错误
+
+**原因**：系统其他第三方源失效（如 `dl.modular.com`），与 OpenTenBase 无关。
+
+**解决**：检查 `/etc/apt/sources.list.d/` 下的其他源文件，移除或禁用失效的源。
+
+### 安装后 `opentenbase-ctl: command not found`
+
+**原因**：安装未完成或 PATH 未包含 `/usr/bin`。
+
+**解决**：
+
+```bash
+# 检查是否安装成功
+dpkg -l | grep opentenbase
+
+# 重新安装
+sudo apt install --reinstall opentenbase
+
+# 检查文件是否存在
+ls -la /usr/bin/opentenbase-ctl
+```
 
 ---
 


### PR DESCRIPTION
中文 README 同步英文版本：
- 删除「从源码构建」「Docker 构建」「本地构建」部分
- 添加故障排查章节（与英文版一致）
- 中英文章节结构完全同步