### PR TITLE
fix: apt update 不再因第三方源失败而误报

### DIFF
--- a/scripts/setup-apt.sh
+++ b/scripts/setup-apt.sh
@@ -291,10 +291,16 @@ EOF
 update_package_list() {
     log_step "更新软件包列表..."
 
-    if apt-get update -qq 2>/dev/null; then
+    # Run apt-get update, but only check if OpenTenBase packages are available
+    # Other third-party repos may fail (e.g. dl.modular.com 404), which is not our fault
+    apt-get update -qq 2>/dev/null || true
+
+    # Verify OpenTenBase package is available
+    if apt-cache show opentenbase &>/dev/null; then
         log_info "软件包列表已更新"
     else
         log_warn "软件包列表更新失败，可能需要手动运行: apt-get update"
+        log_info "提示：如果其他第三方源报错（如 404），请先移除失效的源后重试"
     fi
 }
 


### PR DESCRIPTION
## Summary
- `apt-get update` 的退出码不再作为安装是否成功的判断依据
- 改用 `apt-cache show opentenbase` 验证 OpenTenBase 包是否可用
- 解决第三方源（如 dl.modular.com 404）导致安装脚本误报失败的问题

## Test plan
- [ ] 在安装了 Modular 等第三方源的机器上运行 setup-apt.sh，验证不再因 404 而失败
- [ ] 验证 OpenTenBase 包正常可用时显示成功提示
- [ ] 验证包不可用时显示正确的警告信息

🤖 Generated with [Claude Code](https://claude.com/claude-code)