### PR TITLE
fix: make setup-cluster.sh interactive in piped mode (curl | sudo bash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ sudo dnf install opentenbase
 curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-cluster.sh | sudo bash
 ```
 
+> **Note**: This command works interactively even in piped mode. The script automatically reconnects stdin to your terminal for prompts (port configuration, data directories, etc.).
+
 ---
 
 ## Mirror Acceleration (China-Optimized)

--- a/README_zh.md
+++ b/README_zh.md
@@ -60,6 +60,8 @@ sudo dnf install opentenbase
 curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-cluster.sh | sudo bash
 ```
 
+> **说明**：此命令在管道模式下也能正常交互。脚本会自动将 stdin 重连到终端，支持端口配置、数据目录等交互式提示。
+
 ---
 
 ## 国内镜像加速

--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -3,7 +3,7 @@
 # setup-cluster.sh — OpenTenBase Interactive One-Click Deployment
 # =============================================================================
 # Usage:
-#   curl -sSL <url>/setup-cluster.sh | sudo bash       # non-interactive defaults
+#   curl -sSL <url>/setup-cluster.sh | sudo bash       # interactive (auto-reconnects tty)
 #   sudo bash setup-cluster.sh                          # interactive mode
 #
 # This script handles the full deployment lifecycle:
@@ -17,6 +17,14 @@
 # =============================================================================
 
 set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Reconnect stdin to terminal when running in a pipe (e.g. curl | sudo bash)
+# This allows interactive prompts to work even in piped mode.
+# ---------------------------------------------------------------------------
+if [[ ! -t 0 && -t 1 ]]; then
+    exec 0</dev/tty
+fi
 
 # ---------------------------------------------------------------------------
 # Parse arguments


### PR DESCRIPTION
## Problem

The `setup-cluster.sh` script is labeled as **"Interactive / 交互式"** in both `README.md` and `README_zh.md`, but the documented usage:

```bash
curl -sSL ... | sudo bash
```

**never triggers interactive mode**. When piped, stdin (fd 0) is the pipe, not a terminal, so:

1. `INTERACTIVE=false` — all `ask()` calls return defaults silently, no prompts shown
2. `check_memory()` with < 3GB RAM immediately `exit 1` with no option to continue
3. User never sees port/directory configuration prompts

This means the README documentation is misleading — users expect interaction but get silent defaults or hard exits.

## Root Cause

```bash
INTERACTIVE=true
if [[ ! -t 0 ]]; then    # stdin is pipe → false
    INTERACTIVE=false     # ← always happens in piped mode
fi
```

## Fix

Added 5 lines at the top of the script to reconnect stdin to `/dev/tty` when running in a pipe with a terminal available:

```bash
if [[ ! -t 0 && -t 1 ]]; then
    exec 0</dev/tty
fi
```

This is a well-established bash technique used by many installer scripts. When stdout is a terminal (user is watching), we reopen `/dev/tty` as stdin so `read` prompts work normally.

## Changes

| File | Change |
|------|--------|
| `scripts/setup-cluster.sh` | Reconnect stdin to `/dev/tty` in pipe mode; update header comment |
| `README.md` | Add note explaining interactive mode works in piped mode |
| `README_zh.md` | Add Chinese note explaining interactive mode works in piped mode |

## Testing

Verified the fix logic:
- `curl ... \| sudo bash` → `exec 0</dev/tty` triggers → interactive prompts work
- `sudo bash setup-cluster.sh` → stdin is already tty → no change, works as before
- Non-terminal environments (CI, cron) → `-t 1` is false → no reconnection, safe fallback