### PR TITLE
fix: use /dev/tty char device check instead of tty -s

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -19,10 +19,10 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Reconnect stdin/stderr to terminal when running in a pipe (e.g. curl | sudo bash)
-# This allows interactive prompts to work even in piped mode.
+# Reconnect stdin/stdout/stderr to terminal when running in a pipe
+# (e.g. curl | sudo bash). This allows interactive prompts to work.
 # ---------------------------------------------------------------------------
-if [[ ! -t 0 ]] && tty -s >/dev/null 2>&1; then
+if [[ ! -t 0 ]] && [[ -c /dev/tty ]]; then
     exec 0</dev/tty 1>/dev/tty 2>&1
 fi
 


### PR DESCRIPTION
PR #8 follow-up. The 'tty -s' check fails in Cloud Studio SSH sudo environments, causing interactive mode to not activate. Using '-c /dev/tty' to check if /dev/tty exists as a character device is more reliable across environments.