### PR TITLE
fix: test /dev/tty openability before exec redirect

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -21,9 +21,13 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Reconnect stdin/stdout/stderr to terminal when running in a pipe
 # (e.g. curl | sudo bash). This allows interactive prompts to work.
+# Only redirect if /dev/tty can actually be opened (not in non-interactive SSH).
 # ---------------------------------------------------------------------------
 if [[ ! -t 0 ]] && [[ -c /dev/tty ]]; then
-    exec 0</dev/tty 1>/dev/tty 2>&1
+    # Test if /dev/tty is openable before committing to exec
+    if : <>/dev/tty 2>/dev/null; then
+        exec 0</dev/tty 1>/dev/tty 2>&1
+    fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In non-interactive SSH sessions, /dev/tty exists as a char device but cannot be opened. The exec redirect would crash with 'No such device or address' under set -e. Now test-open with ': <>/dev/tty' before committing to exec.