### PR TITLE
fix: only redirect stdin to /dev/tty, keep stdout/stderr untouched

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -19,14 +19,14 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Reconnect stdin/stdout/stderr to terminal when running in a pipe
-# (e.g. curl | sudo bash). This allows interactive prompts to work.
-# Only redirect if /dev/tty can actually be opened (not in non-interactive SSH).
+# Reconnect stdin to terminal when running in a pipe (e.g. curl | sudo bash).
+# This allows interactive prompts (read) to receive user input.
+# Only stdin is redirected — stdout/stderr stay connected to the original
+# terminal so all output remains visible (important for Web SSH terminals).
 # ---------------------------------------------------------------------------
 if [[ ! -t 0 ]] && [[ -c /dev/tty ]]; then
-    # Test if /dev/tty is openable before committing to exec
     if ( : <>/dev/tty ) 2>/dev/null; then
-        exec 0</dev/tty 1>/dev/tty 2>&1
+        exec 0</dev/tty
     fi
 fi
 


### PR DESCRIPTION
## Problem

In Cloud Studio Web SSH terminals, `exec 1>/dev/tty 2>&1` redirected ALL output to /dev/tty, which is a DIFFERENT output stream than the web terminal. Result: **blank screen** — user sees nothing after running the script.

## Fix

Only redirect stdin (fd 0) to /dev/tty. Keep stdout and stderr connected to the original terminal.

- `read -rp` prompts output to stderr → already visible on web terminal
- `log_info`, `log_step` output to stdout → already visible on web terminal
- Only stdin needs to come from /dev/tty for interactive input

Before: `exec 0</dev/tty 1>/dev/tty 2>&1` → output disappears in Web SSH
After: `exec 0</dev/tty` → output stays visible, input works