### PR TITLE
fix: prevent silent crash when grep -rl finds no match in broken source check

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -178,7 +178,7 @@ check_broken_apt_sources() {
     while IFS= read -r url; do
         [[ -z "$url" ]] && continue
         local src_file
-        src_file=$(grep -rl "$url" /etc/apt/sources.list.d/ 2>/dev/null | head -1)
+        src_file=$(grep -rl "$url" /etc/apt/sources.list.d/ 2>/dev/null | head -1 || true)
         if [[ -n "$src_file" ]]; then
             broken_files+=("$src_file")
         fi


### PR DESCRIPTION
## 问题

`check_broken_apt_sources()` 中第二个 URL 提取模式从 apt 错误信息里抓到了完整的 `URL noble Release` 字符串（而非纯 URL），用 `grep -rl` 在 `sources.list.d/` 中搜索时匹配不到任何文件。由于脚本使用了 `set -euo pipefail`，`grep -rl` 返回 exit code 1 导致 **脚本静默崩溃**——没有任何错误提示，只显示到 "Running pre-flight environment checks..." 就退出。

## 复现环境

Cloud Studio (Ubuntu 24.04, 2GB RAM)：
- 自带失效源 `/etc/apt/sources.list.d/modular-installer.list`（Modular/Mojo 已停止服务）
- `apt-get update` 报错：`The repository 'https://dl.modular.com/public/installer/deb/ubuntu noble Release' no longer has a Release file`
- 第二个 grep 提取出 `https://dl.modular.com/public/installer/deb/ubuntu noble Release`
- 源文件中只有 `https://dl.modular.com/public/installer/deb/ubuntu`（不含 `noble Release`）
- `grep -rl` 无匹配 → exit 1 → `set -e` 杀死脚本

## 修复

在 `grep -rl | head -1` 后添加 `|| true`，使命令替换在无匹配时不会触发 `set -e` 退出：

```diff
-        src_file=$(grep -rl "$url" /etc/apt/sources.list.d/ 2>/dev/null | head -1)
+        src_file=$(grep -rl "$url" /etc/apt/sources.list.d/ 2>/dev/null | head -1 || true)
```

## 测试结果

在 Cloud Studio 上使用修复后的脚本跑完 3 个测试：

| 测试 | 结果 | 说明 |
|------|------|------|
| 失效源检测 | ✅ | 检测到 modular-installer.list 并自动禁用 |
| RAM 不足提示 | ✅ | 显示 3 个替代方案，非交互默认中止 |
| 管道模式 | ✅ | 输出可见不白屏 |

## Test plan

- [x] Cloud Studio 上验证：失效源 + 2GB RAM + 非交互模式
- [ ] 4GB+ RAM 机器上验证：无失效源时正常通过 preflight
- [ ] 管道模式 `curl | sudo bash` 在 Web SSH 终端中交互正常