### PR TITLE
fix: use fd 3 for tty to prevent curl|sudo bash hang in Cloud Studio

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -19,14 +19,16 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Reconnect stdin to terminal when running in a pipe (e.g. curl | sudo bash).
-# This allows interactive prompts (read) to receive user input.
-# Only stdin is redirected — stdout/stderr stay connected to the original
-# terminal so all output remains visible (important for Web SSH terminals).
+# Save terminal as fd 3 when running in a pipe (e.g. curl | sudo bash).
+# Using fd 3 instead of exec 0</dev/tty avoids stealing stdin from the pipe
+# before bash finishes reading the entire script (which causes hangs).
+# Interactive read prompts use <&3 to get user input from the terminal.
 # ---------------------------------------------------------------------------
+TTY_FD=""
 if [[ ! -t 0 ]] && [[ -c /dev/tty ]]; then
     if ( : <>/dev/tty ) 2>/dev/null; then
-        exec 0</dev/tty
+        exec 3</dev/tty
+        TTY_FD=3
     fi
 fi
 
@@ -94,9 +96,9 @@ ask() {
     local answer
     if [[ "$INTERACTIVE" == "true" ]]; then
         if [[ -n "$default" ]]; then
-            read -rp "$(echo -e "${CYAN}${prompt} [${default}]:${NC} ")" answer
+            read -rp "$(echo -e "${CYAN}${prompt} [${default}]:${NC} ")" answer <&"${TTY_FD:-0}"
         else
-            read -rp "$(echo -e "${CYAN}${prompt}:${NC} ")" answer
+            read -rp "$(echo -e "${CYAN}${prompt}:${NC} ")" answer <&"${TTY_FD:-0}"
         fi
         echo "${answer:-$default}"
     else
@@ -109,7 +111,7 @@ ask_yes_no() {
     local default="${2:-y}"
     local answer
     if [[ "$INTERACTIVE" == "true" ]]; then
-        read -rp "$(echo -e "${CYAN}${prompt} [${default}]:${NC} ")" answer
+        read -rp "$(echo -e "${CYAN}${prompt} [${default}]:${NC} ")" answer <&"${TTY_FD:-0}"
         answer="${answer:-$default}"
         [[ "$answer" =~ ^[Yy] ]]
     else


### PR DESCRIPTION
## 问题

`curl | sudo bash` 在 Cloud Studio Web SSH 终端里**完全卡死**，没有任何输出。

## 根因

```bash
# 旧代码（第 29 行）
exec 0</dev/tty
```

`curl | sudo bash` 时，bash 从 stdin（pipe）读取脚本。`exec 0</dev/tty` 在 bash 还没读完 910 行脚本前就把 stdin 从 pipe 切到了 /dev/tty。bash 接下来尝试从 /dev/tty 读剩余脚本 → 卡死。

Cloud Studio Web SSH 里 `/dev/tty` 可用（`-c /dev/tty` 和 `(:<>/dev/tty)` 都通过），所以这段代码会执行。而普通 SSH 非交互模式里 `/dev/tty` 不可用，所以不触发。

## 修复

用 fd 3 代替 fd 0 保存终端，不干扰 pipe stdin：

```diff
- exec 0</dev/tty
+ exec 3</dev/tty
+ TTY_FD=3
```

`read` 命令使用 `<&"${TTY_FD:-0}"` 读取终端输入，stdin 保持连接 pipe 不被切断。

## 测试

在 Cloud Studio（2GB RAM + modular 失效源）验证：

| 测试 | 结果 |
|------|------|
| `cat script \| sudo bash`（pipe 模式） | ✅ 输出完整，不卡死 |
| `echo \| sudo bash script`（pipe 输入） | ✅ preflight 正常运行 |
| 非交互模式默认值 | ✅ RAM 不足自动中止 |

## Test plan

- [x] Cloud Studio Web SSH：`curl \| sudo bash` 不再卡死
- [ ] Cloud Studio Web SSH：交互模式输入 y/n 能正常接收
- [ ] 普通 SSH 终端：`curl \| sudo bash` 正常工作
- [ ] 4GB+ RAM 机器：全流程通过