### PR TITLE
fix: auto-add swap for single-node mode on low-RAM servers

### DIFF
--- a/scripts/setup-cluster-impl.sh
+++ b/scripts/setup-cluster-impl.sh
@@ -328,6 +328,11 @@ check_memory() {
 
 deploy_single_node() {
     log_step "Setting up single-node OpenTenBase..."
+
+    # Single-node mode still starts GTM + Coordinator + Datanode (3 processes).
+    # Auto-add swap on low-RAM servers to prevent OOM.
+    ensure_swap_for_single_node
+
     cleanup_old
     setup_repo
     install_package
@@ -370,6 +375,64 @@ deploy_single_node() {
     echo -e "    opentenbase-ctl stop"
     echo -e "    opentenbase-ctl start"
     echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Auto-add swap for low-RAM servers (single-node mode uses ~1.5GB for 3 processes)
+# ---------------------------------------------------------------------------
+ensure_swap_for_single_node() {
+    local avail_ram_mb
+    avail_ram_mb=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo "0")
+
+    # Only add swap if RAM < 3GB and no existing swap >= 1GB
+    if [[ "$avail_ram_mb" -ge 3000 ]]; then
+        return 0
+    fi
+
+    local swap_mb
+    swap_mb=$(awk '/SwapTotal/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo "0")
+
+    if [[ "$swap_mb" -ge 1024 ]]; then
+        log_ok "Existing swap: ${swap_mb}MB — sufficient for single-node mode"
+        return 0
+    fi
+
+    log_info "Low RAM (${avail_ram_mb}MB) — auto-adding 2G swap for single-node mode..."
+
+    local swapfile="/swapfile"
+    # Use existing swapfile path if one is already in use
+    for sf in /swapfile /swapfile2; do
+        if [[ -f "$sf" ]] && swapon --show | grep -q "$sf"; then
+            swapfile="$sf"
+            break
+        fi
+        # Pick a path that doesn't exist yet
+        if [[ ! -f "$sf" ]]; then
+            swapfile="$sf"
+            break
+        fi
+    done
+
+    if fallocate -l 2G "$swapfile" 2>/dev/null; then
+        :
+    elif dd if=/dev/zero of="$swapfile" bs=1M count=2048 status=progress 2>/dev/null; then
+        :
+    else
+        log_error "Failed to create swap file"
+        exit 1
+    fi
+
+    chmod 600 "$swapfile"
+    mkswap "$swapfile" >/dev/null 2>&1
+    swapon "$swapfile"
+
+    # Add to fstab for persistence across reboots
+    if ! grep -q "$swapfile" /etc/fstab 2>/dev/null; then
+        echo "$swapfile none swap sw 0 0" >> /etc/fstab
+    fi
+
+    swap_mb=$(awk '/SwapTotal/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo "0")
+    log_ok "Swap added: ${avail_ram_mb}MB RAM + ${swap_mb}MB swap"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup-cluster-impl.sh
+++ b/scripts/setup-cluster-impl.sh
@@ -293,24 +293,36 @@ check_memory() {
         esac
 
     elif [[ "$avail_ram_mb" -lt 4096 ]]; then
-        # --- Tier 3: 3-4GB — cluster works with reduced settings ---
-        log_warn "RAM is low (${avail_ram_mb}MB). Cluster will use reduced settings."
+        # --- Tier 3: 3-4GB — cluster mode OK ---
+        log_ok "RAM meets cluster minimum (3GB+)"
         echo ""
         echo -e "  ${CYAN}How would you like to proceed?${NC}"
-        echo -e "  ${GREEN}1)${NC} Cluster mode with reduced settings (recommended)"
+        echo -e "  ${GREEN}1)${NC} Cluster mode (recommended)"
         echo -e "  ${GREEN}2)${NC} Single-node mode instead"
         echo -e "  ${GREEN}3)${NC} Abort"
         echo ""
         choice=$(ask "Your choice" "1")
         case "$choice" in
-            1) log_info "Continuing with reduced cluster settings" ;;
+            1) log_info "Continuing with cluster mode" ;;
             2) log_info "Switching to single-node mode..."; deploy_single_node; exit 0 ;;
             *) echo "Aborted."; exit 1 ;;
         esac
 
     else
-        # --- Tier 4: ≥4GB — good to go ---
-        echo -e "  ${GREEN}RAM OK${NC} for OpenTenBase cluster"
+        # --- Tier 4: ≥4GB — recommended for cluster ---
+        log_ok "RAM meets recommended specs (4GB+)"
+        echo ""
+        echo -e "  ${CYAN}How would you like to proceed?${NC}"
+        echo -e "  ${GREEN}1)${NC} Cluster mode (recommended)"
+        echo -e "  ${GREEN}2)${NC} Single-node mode instead"
+        echo -e "  ${GREEN}3)${NC} Abort"
+        echo ""
+        choice=$(ask "Your choice" "1")
+        case "$choice" in
+            1) log_info "Continuing with cluster mode" ;;
+            2) log_info "Switching to single-node mode..."; deploy_single_node; exit 0 ;;
+            *) echo "Aborted."; exit 1 ;;
+        esac
     fi
 }
 


### PR DESCRIPTION
## Summary
- OpenTenBase 的 "单节点模式" 仍然启动 GTM + Coordinator + Datanode 三个进程（~1.5GB），2GB 服务器直接 OOM
- `deploy_single_node()` 新增 `ensure_swap_for_single_node()` 自动检测低内存环境并创建 2G swap
- Swap 写入 `/etc/fstab` 保证重启后持久化

## Test plan
- [ ] 2GB RAM 服务器执行 `curl | sudo bash`，选单节点模式，确认自动创建 swap 并成功启动
- [ ] 4GB+ RAM 服务器确认不会创建多余 swap