### PR TITLE
fix: add max_wal_senders=5 to low-memory overrides

### DIFF
--- a/scripts/setup-cluster-impl.sh
+++ b/scripts/setup-cluster-impl.sh
@@ -467,6 +467,7 @@ work_mem = 2MB
 maintenance_work_mem = 64MB
 effective_cache_size = 256MB
 max_connections = 20
+max_wal_senders = 5
 wal_buffers = 4MB
 bgwriter_delay = 200ms
 bgwriter_lru_maxpages = 100


### PR DESCRIPTION
## Summary
- `max_wal_senders` 默认值 10 >= `max_connections=20`，PostgreSQL 拒绝启动
- 错误信息：`max_wal_senders must be less than max_connections`
- 新增 `max_wal_senders = 5` 到低内存调参覆盖列表

## Test plan
- [ ] Cloud Studio 2GB 容器：单节点模式 coord 不再报 max_wal_senders 错误