### PR TITLE
docs: fix minimum RAM from 3GB to 4GB, add container limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,16 @@ The installation scripts automatically detect and use the fastest available mirr
 
 | Resource | Minimum | Recommended | Notes |
 |----------|---------|-------------|-------|
-| **RAM** | 3 GB | 4 GB+ | OpenTenBase pooler cache requires ~1GB+ **non-swappable** shared memory per node. A single-machine cluster (GTM + Coordinator + Datanode) needs at least 3GB. |
+| **RAM** | 4 GB | 4 GB+ | OpenTenBase Coordinator requires ~4GB shared memory (SPM cache + connection pool + workfile manager). This is a hard requirement — cannot be reduced by tuning. |
 | **Disk** | 2 GB | 10 GB+ | Binary packages (~500MB) + data directory |
 | **CPU** | 1 core | 2+ cores | GTM thread count auto-detected from CPU cores |
 | **OS** | Ubuntu 20.04+, Debian 11+, RHEL 8+, Fedora 40+ | See platform matrix below | |
 
-> **Important**: The `opentenbase-ctl init` script automatically detects available RAM and tunes `max_connections`, `max_pool_size`, and `shared_buffers` accordingly. On servers with <4GB RAM, reduced settings are applied automatically. On servers with <3GB RAM, a warning is displayed as the cluster may fail to start due to OOM (Out of Memory).
+> **Important**:
+> - **2GB servers cannot run OpenTenBase** — Coordinator's shared memory (~4GB) exceeds available resources. This includes 2GB Cloud Studio containers.
+> - **Containers (Docker/K8s)** have a hard cgroup memory limit and cannot add swap. Use 4GB+ containers only.
+> - The setup script automatically detects memory and container environment, and will abort with clear guidance if requirements are not met.
+> - On real VMs with 3-4GB RAM, the script can add swap to supplement available memory.
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,12 +101,16 @@ curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/Op
 
 | 资源 | 最低要求 | 推荐配置 | 说明 |
 |------|----------|----------|------|
-| **内存** | 3 GB | 4 GB+ | OpenTenBase 连接池缓存需要约 1GB+ **不可 swap** 的共享内存。单机集群（GTM + Coordinator + Datanode）至少需要 3GB。 |
+| **内存** | 4 GB | 4 GB+ | OpenTenBase Coordinator 需要 ~4GB 共享内存（SPM 缓存 + 连接池 + workfile 管理器）。这是硬性要求，无法通过参数调优降低。 |
 | **磁盘** | 2 GB | 10 GB+ | 二进制包（~500MB）+ 数据目录 |
 | **CPU** | 1 核 | 2+ 核 | GTM 线程数根据 CPU 核心数自动检测 |
 | **操作系统** | Ubuntu 20.04+, Debian 11+, RHEL 8+, Fedora 40+ | 见下方平台矩阵 | |
 
-> **重要说明**：`opentenbase-ctl init` 脚本会自动检测可用内存，并根据服务器配置调整 `max_connections`、`max_pool_size` 和 `shared_buffers` 参数。内存 <4GB 的服务器会自动使用精简配置，<3GB 的服务器会显示警告（集群可能因 OOM 无法启动）。
+> **重要说明**：
+> - **2GB 服务器无法运行 OpenTenBase** — Coordinator 共享内存需求（~4GB）超出可用资源。包括 2GB 的 Cloud Studio 容器。
+> - **容器环境（Docker/K8s）**有硬性 cgroup 内存限制且无法添加 swap，请使用 4GB+ 容器。
+> - 安装脚本会自动检测内存和容器环境，不满足要求时会中止并给出明确提示。
+> - 真实 VM 环境 3-4GB 内存时，脚本可自动添加 swap 补充内存。
 
 ---
 

--- a/scripts/setup-cluster-impl.sh
+++ b/scripts/setup-cluster-impl.sh
@@ -240,7 +240,7 @@ check_memory() {
     if [[ "$avail_ram_mb" -lt 2000 ]]; then
         # --- Tier 1: <2GB — cannot run OpenTenBase at all ---
         issues_found=$((issues_found + 1))
-        log_error "Insufficient RAM (${avail_ram_mb}MB). OpenTenBase needs at least 3GB."
+        log_error "Insufficient RAM (${avail_ram_mb}MB). OpenTenBase needs at least 4GB."
         echo ""
         echo -e "  ${RED}OpenTenBase cannot run on this server.${NC}"
         echo -e "  ${YELLOW}Even single-node mode requires ~4GB shared memory for the Coordinator.${NC}"
@@ -277,7 +277,7 @@ check_memory() {
 
         # Real VM: can add swap
         issues_found=$((issues_found + 1))
-        log_error "RAM ${avail_ram_mb}MB is below cluster minimum (3GB)."
+        log_error "RAM ${avail_ram_mb}MB is below recommended minimum (4GB)."
         echo ""
         echo -e "  ${CYAN}How would you like to proceed?${NC}"
         echo -e "  ${GREEN}1)${NC} Single-node mode with auto swap (recommended)"
@@ -315,7 +315,7 @@ check_memory() {
 
     elif [[ "$avail_ram_mb" -lt 4096 ]]; then
         # --- Tier 3: 3-4GB — cluster mode OK ---
-        log_ok "RAM meets cluster minimum (3GB+)"
+        log_ok "RAM meets minimum requirement (3GB+)"
         echo ""
         echo -e "  ${CYAN}How would you like to proceed?${NC}"
         echo -e "  ${GREEN}1)${NC} Cluster mode (recommended)"


### PR DESCRIPTION
## Summary
- 最低内存 3GB → 4GB（与实际测试一致：Coordinator 共享内存 ~4GB）
- 新增容器限制说明：无 swap、cgroup 硬限制、2GB 容器不可行
- 脚本错误信息同步更新 "3GB" → "4GB"

## 修改文件
| 文件 | 修改 |
|------|------|
| README.md | RAM 最低 3GB → 4GB，新增容器和 2GB 服务器说明 |
| README_zh.md | 同步中文更新 |
| scripts/setup-cluster-impl.sh | 错误信息 3GB → 4GB |