### PR TITLE
Add pgvector IVFFlat index diagnostics workflow

### DIFF
--- a/docs/diagnostic-results/pgvector-diagnostics-local-validation.txt
+++ b/docs/diagnostic-results/pgvector-diagnostics-local-validation.txt
@@ -52,3 +52,50 @@ Output summary:
   benchmark_required   | info
   ivfflat_index_inventory returned 0 rows in the local PostgreSQL validation
   database because pgvector IVFFlat indexes were not present there.
+
+OpenTenBase remote validation:
+  Environment:
+    Host: mdnzwy.fkpw3ukb.ssh.cloudstudio.work
+    OpenTenBase cluster: gtm/dn1/coord RUNNING
+    Filesystem after validation: overlay 31G total, 28G available
+
+  SQL file:
+    /workspace/OpenTenBase/contrib/pgvector/bench/ivfflat_diagnostics.sql
+
+  Memory parser and estimator:
+    SELECT
+      pgvector_bench.parse_memory_mb('512MB'),
+      pgvector_bench.parse_memory_mb('1GB'),
+      pgvector_bench.recommend_ivfflat_lists(100000,128),
+      pgvector_bench.estimate_ivfflat_build_memory_mb(100000,128,1000);
+
+  Output:
+    512|1024.0|1000|246
+
+  Low-memory, low-probes diagnostic:
+    SELECT check_name, status, detail, recommendation
+    FROM pgvector_bench.diagnose_ivfflat_build(100000,128,1000,10,0.90,'64MB');
+
+  Output:
+    lists|ok|rows=100000 dims=128 lists=1000 recommended_lists=1000|lists is within the basic heuristic range; validate with workload data
+    maintenance_work_mem|risk|estimated_build_memory=246MB configured_maintenance_work_mem=64.00MB|increase maintenance_work_mem to at least 246MB or reduce lists/rows per build
+    probes|risk|probes=10 lists=1000 probe_ratio=0.0100 target_recall=0.90|low probes may cause poor recall; benchmark higher probes such as lists*0.3, lists*0.5, and lists
+    benchmark_required|info|IVFFlat quality depends on data distribution, metric, topk, and query workload|run bench/run_ivfflat_benchmark.sh with representative data and save CSV plus EXPLAIN plan evidence
+
+  Higher-memory, higher-probes diagnostic:
+    SELECT check_name, status, detail, recommendation
+    FROM pgvector_bench.diagnose_ivfflat_build(100000,128,1000,500,0.90,'512MB');
+
+  Output:
+    lists|ok|rows=100000 dims=128 lists=1000 recommended_lists=1000|lists is within the basic heuristic range; validate with workload data
+    maintenance_work_mem|ok|estimated_build_memory=246MB configured_maintenance_work_mem=512.00MB|memory setting has basic headroom for this index build
+    probes|ok|probes=500 lists=1000 probe_ratio=0.5000 target_recall=0.90|probe ratio is plausible; validate using recall@k benchmark
+    benchmark_required|info|IVFFlat quality depends on data distribution, metric, topk, and query workload|run bench/run_ivfflat_benchmark.sh with representative data and save CSV plus EXPLAIN plan evidence
+
+  IVFFlat inventory:
+    SELECT schema_name, table_name, index_name, index_kind
+    FROM pgvector_bench.ivfflat_index_inventory
+    LIMIT 5;
+
+  Output:
+    pgvector_bench|items|items_embedding_ivfflat_idx|ivfflat

--- a/docs/diagnostic-results/pgvector-diagnostics-local-validation.txt
+++ b/docs/diagnostic-results/pgvector-diagnostics-local-validation.txt
@@ -1,0 +1,54 @@
+Environment:
+  PostgreSQL 14.22 (Homebrew) on aarch64-apple-darwin24.6.0
+  Purpose: SQL syntax and diagnostic function logic validation.
+  Note: This validates generic SQL/plpgsql logic. OpenTenBase remote validation
+  should be rerun when the CloudStudio SSH endpoint is reachable.
+
+Command:
+  psql -X -v ON_ERROR_STOP=1 -d postgres \
+    -f /Users/blackevil/Documents/申请书/OpenTenBase-source/contrib/pgvector/bench/ivfflat_diagnostics.sql
+
+Memory parser and list/memory estimator:
+  SELECT
+    pgvector_bench.parse_memory_mb('512MB'),
+    pgvector_bench.parse_memory_mb('1GB'),
+    pgvector_bench.parse_memory_mb('64kB'),
+    pgvector_bench.recommend_ivfflat_lists(100000,128),
+    pgvector_bench.estimate_ivfflat_build_memory_mb(100000,128,1000);
+
+Output:
+  512|1024.0|0.06250000000000000000|1000|246
+
+Low-memory, low-probes diagnostic:
+  SELECT check_name, status, detail, recommendation
+  FROM pgvector_bench.diagnose_ivfflat_build(100000,128,1000,10,0.90,'64MB');
+
+Output:
+  lists|ok|rows=100000 dims=128 lists=1000 recommended_lists=1000|lists is within the basic heuristic range; validate with workload data
+  maintenance_work_mem|risk|estimated_build_memory=246MB configured_maintenance_work_mem=64.00MB|increase maintenance_work_mem to at least 246MB or reduce lists/rows per build
+  probes|risk|probes=10 lists=1000 probe_ratio=0.0100 target_recall=0.90|low probes may cause poor recall; benchmark higher probes such as lists*0.3, lists*0.5, and lists
+  benchmark_required|info|IVFFlat quality depends on data distribution, metric, topk, and query workload|run bench/run_ivfflat_benchmark.sh with representative data and save CSV plus EXPLAIN plan evidence
+
+Higher-memory, higher-probes diagnostic:
+  SELECT check_name, status, detail, recommendation
+  FROM pgvector_bench.diagnose_ivfflat_build(100000,128,1000,500,0.90,'512MB');
+
+Output:
+  lists|ok|rows=100000 dims=128 lists=1000 recommended_lists=1000|lists is within the basic heuristic range; validate with workload data
+  maintenance_work_mem|ok|estimated_build_memory=246MB configured_maintenance_work_mem=512.00MB|memory setting has basic headroom for this index build
+  probes|ok|probes=500 lists=1000 probe_ratio=0.5000 target_recall=0.90|probe ratio is plausible; validate using recall@k benchmark
+  benchmark_required|info|IVFFlat quality depends on data distribution, metric, topk, and query workload|run bench/run_ivfflat_benchmark.sh with representative data and save CSV plus EXPLAIN plan evidence
+
+Script-level validation:
+  DBNAME=postgres ROW_COUNT=100000 DIMS=128 LISTS=1000 PROBES=10 \
+    TARGET_RECALL=0.90 MAINTENANCE_WORK_MEM=64MB \
+    SQL_FILE=/Users/blackevil/Documents/申请书/OpenTenBase-source/contrib/pgvector/bench/ivfflat_diagnostics.sql \
+    scripts/pgvector-index-diagnostics.sh
+
+Output summary:
+  lists                | ok
+  maintenance_work_mem | risk
+  probes               | risk
+  benchmark_required   | info
+  ivfflat_index_inventory returned 0 rows in the local PostgreSQL validation
+  database because pgvector IVFFlat indexes were not present there.

--- a/docs/pgvector-ai-reproducible-sop.md
+++ b/docs/pgvector-ai-reproducible-sop.md
@@ -1,0 +1,340 @@
+# pgvector 项目一/项目二 AI 可复现工作流 SOP
+
+## 1. 目标
+
+本 SOP 用于指导 AI Agent 在 OpenTenBase/TDSQL-A pgvector 方向完成两类任务：
+
+- 项目一：向量检索插件 pgvector 查询性能优化。
+- 项目二：向量索引构建与诊断能力增强。
+
+该流程强调可复现、可扩展、可审查。它不固定某一组数据量、服务器、参数或优化点，而是规定每个阶段必须产生的证据、决策门和交付物，让不同 AI 在不同环境中也能稳定产出可比较结果。
+
+## 2. 核心原则
+
+1. 先建立基线，再谈优化。
+2. 所有性能结论必须同时报告正确性或 recall。
+3. 所有 benchmark 必须保存命令、环境、原始数据、图表和 `EXPLAIN` 证据。
+4. 参数不写死，用矩阵生成：`rows`、`dims`、`lists`、`probes`、`metrics` 均可按环境预算调整。
+5. 每个阶段都有退出条件，未通过则回到上一个阶段，而不是强行写结论。
+6. 报告只写已经验证的内容，规划内容必须明确标记为下一阶段计划。
+
+## 3. 输入
+
+AI Agent 启动前需要收集：
+
+| 输入 | 示例 | 可替换性 |
+| --- | --- | --- |
+| 仓库地址 | `OpenTenBase-Packages`、OpenTenBase 源码仓库 | 可替换为 fork 或上游 |
+| 服务器 | SSH 远程开发环境 | 可替换为本地、云服务器、容器 |
+| 数据库版本 | OpenTenBase 5.0 | 可替换为其他兼容版本 |
+| 插件目录 | `contrib/pgvector` | 若目录不同，先定位源码 |
+| 项目方向 | 项目一或项目二 | 可单独执行，也可串联 |
+| 资源预算 | CPU、内存、磁盘、运行时长 | 决定 benchmark 矩阵规模 |
+
+## 4. 通用阶段
+
+### 阶段 0：环境画像
+
+执行内容：
+
+- 确认仓库分支、远程地址、未提交改动。
+- 确认服务器可连接。
+- 确认安装方式：APT、源码编译、Docker、已有集群。
+- 记录 CPU、内存、磁盘、OS、OpenTenBase 版本。
+- 验证 `CREATE EXTENSION vector`。
+
+产物：
+
+```text
+docs/<project>/environment.md
+```
+
+退出条件：
+
+- 能执行基础向量插入和距离查询。
+- 能确定后续 benchmark 使用的数据库连接参数。
+
+失败处理：
+
+- Docker 不可用时切换到 APT 或源码安装。
+- APT 源异常时记录坏源并隔离处理。
+- 磁盘不足时先清理日志或降低 benchmark 规模。
+
+### 阶段 1：基线工具准备
+
+执行内容：
+
+- 在 `contrib/pgvector/bench/` 建立 benchmark 工具。
+- 工具必须支持环境变量配置，而不是写死参数。
+- 生成 deterministic 数据，保存 CSV 结果。
+- 自动输出 `EXPLAIN` plan。
+- 对 exact 查询和 approximate 查询分别计时。
+
+最低参数集合：
+
+```text
+ROWS
+DIMS
+QUERIES
+TOPK
+LISTS
+PROBES_LIST
+METRICS
+MAINTENANCE_WORK_MEM
+OUTPUT
+PLAN_OUTPUT
+```
+
+产物：
+
+```text
+patches/pgvector-ivfflat-benchmark-tools.patch
+docs/<project>/benchmark-data/*.csv
+docs/<project>/benchmark-data/*_plans.txt
+```
+
+退出条件：
+
+- `bash -n` 或等效语法检查通过。
+- 小规模 smoke benchmark 通过。
+- 至少一个 metric 的 plan 显示 `Index Scan using ... ivfflat ...`。
+
+### 阶段 2：正式 benchmark 矩阵
+
+AI 不应固定某一组参数，而应根据资源预算选择矩阵。
+
+推荐生成规则：
+
+| 环境 | rows | dims | queries | lists | probes |
+| --- | ---: | ---: | ---: | ---: | --- |
+| 低配 | 10000-50000 | 64-128 | 10-30 | `sqrt(rows)` 附近 | `1, 5, 10, 50, lists` |
+| 中配 | 100000-300000 | 128-384 | 30-100 | `sqrt(rows) * 2-4` | `1, 5, 10, 50, 100, lists/2, lists` |
+| 高配 | 1000000+ | 384-768 | 100+ | 分多档 | 按 recall 目标自适应 |
+
+必须覆盖：
+
+```text
+l2
+ip
+cosine
+```
+
+退出条件：
+
+- 每个 metric 至少 5 档 probes。
+- 每个 metric 有 recall/latency 曲线。
+- 每个 metric 有 IVFFlat Index Scan 证据。
+
+失败处理：
+
+- 索引构建内存不足：提高 `MAINTENANCE_WORK_MEM` 或降低 `LISTS`。
+- recall 全为 1.0：增大 rows/lists，降低 probes，或引入更难的数据分布。
+- 查询没有走索引：检查 `ORDER BY` 是否只按距离表达式排序，检查 opclass/operator 是否匹配。
+
+### 阶段 3：数据整理与图表
+
+图表至少包含：
+
+- recall@k vs probes。
+- avg latency vs probes。
+- p95 latency vs probes。
+- exact scan 对照线或表格。
+
+产物：
+
+```text
+docs/<project>/figures/pgvector-recall-vs-probes.svg
+docs/<project>/figures/pgvector-avg-latency-vs-probes.svg
+docs/<project>/figures/pgvector-p95-latency-vs-probes.svg
+```
+
+退出条件：
+
+- 图表可解析、非空。
+- 图表中的点数与 CSV 行数一致。
+- 报告中的数字来自 CSV，不手抄未验证数据。
+
+## 5. 项目一工作流：查询性能优化
+
+### 5.1 目标
+
+在 L2/IP/Cosine 场景下，保证结果正确性和 recall 稳定，同时降低查询耗时或提升吞吐。
+
+### 5.2 执行步骤
+
+1. 建立 IVFFlat benchmark 基线。
+2. 确认查询计划走 IVFFlat。
+3. 识别 probes 与 recall/latency 的边界。
+4. 选择优化候选：
+   - 距离计算函数。
+   - IVFFlat 扫描路径。
+   - tuple fetch 或排序路径。
+   - OpenTenBase 分布式执行开销。
+5. 使用 profiling 定位热点。
+6. 实施低风险代码改动。
+7. 复跑同一 benchmark 矩阵。
+8. 输出 before/after 对比报告。
+
+### 5.3 决策门
+
+| 决策点 | Go 条件 | No-Go 处理 |
+| --- | --- | --- |
+| 是否进入 C 代码优化 | baseline 稳定且 plan 正确 | 先修 benchmark |
+| 是否接受优化 | recall 不下降，延迟或吞吐改善 | 回滚或改为实验记录 |
+| 是否提交 PR | 有测试、报告、复现命令 | 补齐验证 |
+
+### 5.4 交付物
+
+```text
+patches/pgvector-ivfflat-benchmark-tools.patch
+docs/pgvector-performance-development-report.md
+docs/benchmark-data/*.csv
+docs/figures/*.svg
+优化代码 PR 或实验补丁
+```
+
+## 6. 项目二工作流：索引构建与诊断增强
+
+### 6.1 目标
+
+让用户更容易发现“索引建得不合理、召回低、构建慢、内存不足、查询没走索引”等问题，并给出可执行建议。
+
+### 6.2 执行步骤
+
+1. 收集项目一 benchmark 观测数据。
+2. 建立诊断对象：
+   - 观测表。
+   - 参数推荐函数。
+   - 低召回风险检测 SQL。
+   - 索引构建内存建议 SQL。
+3. 覆盖异常场景：
+   - `maintenance_work_mem` 不足。
+   - `ORDER BY` 写法导致索引失效。
+   - `probes` 过低导致 recall 断崖。
+   - 数据分布不均导致 recall 波动。
+4. 输出诊断报告和调优模板。
+5. 将诊断工具纳入 patch 或独立 PR。
+
+### 6.3 推荐函数设计
+
+函数不应只返回一个固定答案，而应返回：
+
+```text
+recommended_lists
+recommended_probes
+estimated_recall
+expected_avg_latency_ms
+maintenance_work_mem
+recommendation_source
+risk_level
+rationale
+```
+
+推荐策略：
+
+- 命中已有观测数据时，返回 measured 推荐。
+- 未命中时，返回 heuristic 推荐。
+- heuristic 必须提示用户运行 benchmark 复测。
+
+### 6.4 交付物
+
+```text
+contrib/pgvector/bench/ivfflat_recommendation.sql
+docs/pgvector-optimization-roadmap-engineering-plan.md
+docs/pgvector-index-diagnostics-report.md
+docs/pgvector-production-tuning-template.md
+```
+
+## 7. AI Agent 执行模板
+
+### 7.1 每轮执行前
+
+AI 必须确认：
+
+```text
+当前分支
+git status
+远程仓库
+目标项目：项目一或项目二
+本轮目标
+预期产物
+```
+
+### 7.2 每轮执行中
+
+AI 必须保留：
+
+```text
+运行命令
+输出文件路径
+失败原因
+修复动作
+复验命令
+```
+
+### 7.3 每轮执行后
+
+AI 必须输出：
+
+```text
+完成了什么
+验证了什么
+哪些数据可用于报告
+哪些结论仍然只是计划
+下一步建议
+```
+
+## 8. 可扩展节点
+
+以下节点允许替换，避免把流程钉死：
+
+| 节点 | 默认实现 | 可替换实现 |
+| --- | --- | --- |
+| 数据生成 | deterministic random vectors | clustered、skewed、真实 embedding |
+| 指标 | avg/p95/recall@k | QPS、p99、内存峰值、索引构建耗时 |
+| 图表 | SVG line charts | PNG、PDF、dashboard |
+| 安装方式 | APT | 源码编译、Docker、已有集群 |
+| 推荐策略 | measured-first heuristic | 回归模型、网格搜索、贝叶斯优化 |
+| profiling | perf | gprof、eBPF、火焰图工具 |
+| 报告 | Markdown | PDF、PPT、PR description |
+
+## 9. 禁止事项
+
+- 禁止只报告延迟，不报告 recall。
+- 禁止没有 `EXPLAIN` 证据就宣称使用了 IVFFlat。
+- 禁止将 smoke benchmark 当正式结论。
+- 禁止把某一次服务器上的参数写成普适默认值。
+- 禁止把 heuristic 推荐写成确定性能保证。
+- 禁止忽略失败场景；失败必须变成诊断能力或风险说明。
+
+## 10. 最终交付包结构
+
+建议项目提交包使用以下结构：
+
+```text
+docs/
+  benchmark-data/
+  figures/
+  pgvector-performance-development-report.md
+  pgvector-optimization-roadmap-engineering-plan.md
+  pgvector-index-diagnostics-report.md
+patches/
+  pgvector-ivfflat-benchmark-tools.patch
+scripts 或 contrib patch/
+  benchmark and diagnostics tools
+```
+
+## 11. 交付判定
+
+满足以下条件可认为一个项目阶段完成：
+
+- 有代码或工具产物。
+- 有原始数据。
+- 有图表。
+- 有验证命令。
+- 有失败场景记录。
+- 有可复现报告。
+- 有可提交 PR 或 issue。
+
+如果缺少其中任一项，只能标记为“阶段性探索”，不能标记为“完成交付”。
+

--- a/docs/pgvector-index-diagnostics-report.md
+++ b/docs/pgvector-index-diagnostics-report.md
@@ -1,0 +1,190 @@
+# pgvector 向量索引构建与诊断能力增强技术报告
+
+## 1. 项目方向
+
+本阶段选择“项目二：向量索引构建与诊断能力增强”作为独立交付方向，目标是让 OpenTenBase/TDSQL-A 用户更容易发现以下问题：
+
+- IVFFlat 索引构建慢或失败。
+- `maintenance_work_mem` 不足导致索引构建失败。
+- `lists/probes` 设置不合理导致召回率低或延迟过高。
+- 查询写法不满足 IVFFlat 计划条件，导致退化为 Seq Scan。
+- 数据规模、维度、目标召回变化后缺少可执行参数建议。
+
+项目一已经完成可复现 benchmark 和 100000 行、128 维、L2/IP/Cosine 的 recall/latency 基线。项目二在此基础上把“测试数据”进一步沉淀为“诊断工具”和“调优流程”。
+
+## 2. 交付物
+
+本阶段新增：
+
+```text
+patches/pgvector-ivfflat-diagnostics-tools.patch
+scripts/pgvector-index-diagnostics.sh
+docs/pgvector-index-diagnostics-report.md
+docs/pgvector-production-tuning-template.md
+docs/pgvector-ai-reproducible-sop.md
+```
+
+源码补丁新增：
+
+```text
+contrib/pgvector/bench/ivfflat_diagnostics.sql
+```
+
+诊断 SQL 提供：
+
+- `pgvector_bench.parse_memory_mb(text)`
+- `pgvector_bench.estimate_ivfflat_build_memory_mb(row_count, dims, lists)`
+- `pgvector_bench.recommend_ivfflat_lists(row_count, dims)`
+- `pgvector_bench.diagnose_ivfflat_build(row_count, dims, lists, probes, target_recall, maintenance_work_mem)`
+- `pgvector_bench.ivfflat_index_inventory`
+
+## 3. 诊断设计
+
+### 3.1 构建内存风险
+
+IVFFlat 构建需要较大的工作内存。项目一实测中，`ROWS=100000`、`DIMS=128`、`LISTS=1000` 在默认 `maintenance_work_mem=64MB` 下出现过索引构建失败。
+
+诊断函数会估算构建内存，并和当前或指定的 `maintenance_work_mem` 对比：
+
+```sql
+SELECT *
+FROM pgvector_bench.diagnose_ivfflat_build(
+  row_count => 100000,
+  dims => 128,
+  lists => 1000,
+  probes => 10,
+  target_recall => 0.90,
+  maintenance_work_mem => '64MB'
+);
+```
+
+预期风险：
+
+```text
+maintenance_work_mem = risk
+recommendation = increase maintenance_work_mem ... or reduce lists/rows per build
+```
+
+### 3.2 lists/probes 风险
+
+诊断函数不会把某一组参数写成普适答案，而是返回风险等级和建议：
+
+- `probes/lists` 过低：提示召回率风险。
+- `probes = lists`：提示召回率通常较高，但延迟可能接近或超过 exact scan。
+- 未显式传入 `lists/probes`：按数据规模、维度和目标召回给出启发式起点。
+
+### 3.3 索引清单
+
+`ivfflat_index_inventory` 视图用于发现当前数据库中已有的 IVFFlat 索引：
+
+```sql
+SELECT schema_name, table_name, index_name, pg_size_pretty(index_bytes), index_definition
+FROM pgvector_bench.ivfflat_index_inventory;
+```
+
+该视图可用于报告已有索引数量、索引大小和索引定义，帮助判断是否存在重复索引、错误 opclass 或非预期表。
+
+## 4. 使用方式
+
+加载诊断 SQL：
+
+```bash
+psql -d postgres -f contrib/pgvector/bench/ivfflat_diagnostics.sql
+```
+
+使用安装包仓库脚本运行诊断：
+
+```bash
+PGHOST=127.0.0.1 PGPORT=5432 PGUSER=opentenbase DBNAME=postgres \
+ROW_COUNT=100000 DIMS=128 LISTS=1000 PROBES=10 \
+TARGET_RECALL=0.90 MAINTENANCE_WORK_MEM=64MB \
+SQL_FILE=/workspace/OpenTenBase/contrib/pgvector/bench/ivfflat_diagnostics.sql \
+scripts/pgvector-index-diagnostics.sh
+```
+
+高召回配置诊断：
+
+```bash
+PGHOST=127.0.0.1 PGPORT=5432 PGUSER=opentenbase DBNAME=postgres \
+ROW_COUNT=100000 DIMS=128 LISTS=1000 PROBES=500 \
+TARGET_RECALL=0.90 MAINTENANCE_WORK_MEM=512MB \
+scripts/pgvector-index-diagnostics.sh
+```
+
+## 5. 异常场景覆盖
+
+| 场景 | 诊断能力 | 建议 |
+| --- | --- | --- |
+| `maintenance_work_mem` 过低 | `maintenance_work_mem = risk` | 提高内存或降低 lists/分批构建 |
+| 低 probes 高 recall 目标 | `probes = risk/warn` | benchmark `lists*0.3`、`lists*0.5`、`lists` |
+| probes 等于 lists | `probes = warn` | 对比 exact scan，避免延迟超过收益 |
+| 未设置 lists | 返回推荐 lists | 以推荐值为起点，再跑 benchmark |
+| 查询未命中索引 | 项目一 benchmark plan 输出识别 | 确认 `ORDER BY` 只包含距离表达式 |
+
+## 6. 与项目一的关系
+
+项目一解决“如何测”和“测出了什么”；项目二解决“用户看到问题后如何定位和调参”。
+
+项目一产物：
+
+- benchmark 工具。
+- recall/latency 数据。
+- plan 证据。
+- 参数推荐初版。
+
+项目二新增：
+
+- 构建内存估算。
+- lists/probes 风险分级。
+- IVFFlat 索引清单。
+- 可复用诊断脚本。
+- 生产调优模板。
+
+## 7. 验证状态
+
+本地已完成函数级验证，结果文件：
+
+```text
+docs/diagnostic-results/pgvector-diagnostics-local-validation.txt
+```
+
+验证环境：
+
+```text
+PostgreSQL 14.22 (Homebrew) on aarch64-apple-darwin24.6.0
+```
+
+已验证：
+
+- `scripts/pgvector-index-diagnostics.sh` shell 语法检查。
+- `patches/pgvector-ivfflat-diagnostics-tools.patch` 生成检查。
+- SOP、报告、调优模板路径检查。
+- `parse_memory_mb('512MB') = 512`。
+- `recommend_ivfflat_lists(100000, 128) = 1000`。
+- `estimate_ivfflat_build_memory_mb(100000,128,1000) = 246`，能够覆盖项目一中 64MB 构建失败的风险。
+- `diagnose_ivfflat_build(100000,128,1000,10,0.90,'64MB')` 返回 `maintenance_work_mem = risk` 和 `probes = risk`。
+- `diagnose_ivfflat_build(100000,128,1000,500,0.90,'512MB')` 返回 `maintenance_work_mem = ok` 和 `probes = ok`。
+- `scripts/pgvector-index-diagnostics.sh` 已串联加载 SQL、执行诊断和查询索引清单。
+
+远程 OpenTenBase 验证状态：
+
+- 远程 CloudStudio SSH 当前直接断开，暂时无法补充分布式 OpenTenBase 实测输出。
+- 由于诊断 SQL 主要为标准 SQL/PLpgSQL 逻辑，本地 PostgreSQL 已覆盖语法和主要函数行为。
+- `ivfflat_index_inventory` 的 OpenTenBase 实库索引清单仍需在远程恢复后补测。
+
+远程恢复后的补测命令：
+
+1. 加载 `ivfflat_diagnostics.sql`。
+2. 验证低内存场景返回 `risk`。
+3. 验证高 probes 场景返回 `warn/ok`。
+4. 查询 `ivfflat_index_inventory`，确认能列出现有 IVFFlat 索引。
+
+如果远程环境临时不可用，应保留 SQL、命令和预期输出，待环境恢复后补充实测结果，不应伪造验证数据。
+
+## 8. 后续增强
+
+1. 将项目一 benchmark CSV 自动导入观测表，形成更丰富的 measured recommendation。
+2. 增加 clustered/skewed 数据集，验证非均匀分布下的低召回风险。
+3. 增加索引构建耗时采样，输出构建耗时与 `maintenance_work_mem` 的关系。
+4. 对接 OpenTenBase `pg_stat_cluster_activity`、`pg_stat_cluster_query_memory` 等视图，补充分布式资源观测。
+5. 形成独立 PR：`pgvector IVFFlat diagnostics tools`。

--- a/docs/pgvector-index-diagnostics-report.md
+++ b/docs/pgvector-index-diagnostics-report.md
@@ -166,20 +166,17 @@ PostgreSQL 14.22 (Homebrew) on aarch64-apple-darwin24.6.0
 - `diagnose_ivfflat_build(100000,128,1000,500,0.90,'512MB')` 返回 `maintenance_work_mem = ok` 和 `probes = ok`。
 - `scripts/pgvector-index-diagnostics.sh` 已串联加载 SQL、执行诊断和查询索引清单。
 
-远程 OpenTenBase 验证状态：
+远程 OpenTenBase 已完成实库验证：
 
-- 远程 CloudStudio SSH 当前直接断开，暂时无法补充分布式 OpenTenBase 实测输出。
-- 由于诊断 SQL 主要为标准 SQL/PLpgSQL 逻辑，本地 PostgreSQL 已覆盖语法和主要函数行为。
-- `ivfflat_index_inventory` 的 OpenTenBase 实库索引清单仍需在远程恢复后补测。
-
-远程恢复后的补测命令：
-
-1. 加载 `ivfflat_diagnostics.sql`。
-2. 验证低内存场景返回 `risk`。
-3. 验证高 probes 场景返回 `warn/ok`。
-4. 查询 `ivfflat_index_inventory`，确认能列出现有 IVFFlat 索引。
-
-如果远程环境临时不可用，应保留 SQL、命令和预期输出，待环境恢复后补充实测结果，不应伪造验证数据。
+- CloudStudio 远程集群已启动，`gtm/dn1/coord` 均为 `RUNNING`。
+- `ivfflat_diagnostics.sql` 已加载到 OpenTenBase。
+- `parse_memory_mb('512MB') = 512`，`parse_memory_mb('1GB') = 1024.0`。
+- `recommend_ivfflat_lists(100000,128) = 1000`。
+- `estimate_ivfflat_build_memory_mb(100000,128,1000) = 246`。
+- `diagnose_ivfflat_build(100000,128,1000,10,0.90,'64MB')` 返回 `maintenance_work_mem = risk` 和 `probes = risk`。
+- `diagnose_ivfflat_build(100000,128,1000,500,0.90,'512MB')` 返回 `maintenance_work_mem = ok` 和 `probes = ok`。
+- `ivfflat_index_inventory` 能识别远程库中的 `pgvector_bench.items_embedding_ivfflat_idx`，类型为 `ivfflat`。
+- 验证后磁盘正常，根分区约 28GB 可用，`dn1.log` 和 `coord.log` 均保持在 KB 级。
 
 ## 8. 后续增强
 

--- a/docs/pgvector-production-tuning-template.md
+++ b/docs/pgvector-production-tuning-template.md
@@ -1,0 +1,147 @@
+# OpenTenBase pgvector 生产调优模板
+
+## 1. 基本信息
+
+| 项目 | 填写 |
+| --- | --- |
+| 业务场景 | 例如 RAG、相似商品、日志向量检索 |
+| 向量来源 | 例如 embedding model 名称和版本 |
+| 数据规模 | rows = |
+| 向量维度 | dims = |
+| 距离类型 | L2 / Inner Product / Cosine |
+| TopK | |
+| 目标 recall | |
+| 延迟预算 | avg / p95 / p99 |
+| OpenTenBase 版本 | |
+| 节点形态 | 单机 / 分布式 |
+
+## 2. 建索引前检查
+
+```sql
+SELECT *
+FROM pgvector_bench.diagnose_ivfflat_build(
+  row_count => <rows>,
+  dims => <dims>,
+  lists => NULL,
+  probes => NULL,
+  target_recall => <target_recall>,
+  maintenance_work_mem => current_setting('maintenance_work_mem')
+);
+```
+
+检查项：
+
+- `lists` 是否合理。
+- `maintenance_work_mem` 是否低于估算值。
+- 初始 `probes` 是否存在低召回风险。
+- 是否需要先降低数据规模做 smoke benchmark。
+
+## 3. 推荐配置起点
+
+| rows | dims | 建议 lists 起点 | 建议 probes 起点 | maintenance_work_mem 起点 |
+| ---: | ---: | ---: | ---: | --- |
+| 10000-50000 | 64-128 | `sqrt(rows) * 2` 附近 | `lists * 0.1` 到 `lists * 0.5` | 128MB-256MB |
+| 100000-300000 | 128-384 | `sqrt(rows) * 3.2` 附近 | `lists * 0.3` 到 `lists * 0.75` | 512MB-1GB |
+| 1000000+ | 384+ | 分多档验证 | 按 recall 目标逐步提升 | 1GB+，按实际构建内存估算 |
+
+注意：表格只作为起点，不是生产保证。正式上线必须使用业务数据复跑 recall/latency benchmark。
+
+## 4. Benchmark 命令模板
+
+```bash
+cd contrib/pgvector
+
+PGHOST=<host> PGPORT=<port> PGUSER=<user> DBNAME=<db> \
+ROWS=<rows> DIMS=<dims> QUERIES=<queries> TOPK=<topk> \
+LISTS=<lists> PROBES_LIST="1 5 10 50 100 <lists/2> <lists>" \
+METRICS="l2 ip cosine" MAINTENANCE_WORK_MEM=<mem> \
+bench/run_ivfflat_benchmark.sh
+```
+
+必须保存：
+
+```text
+bench/results/*.csv
+bench/results/*_plans.txt
+```
+
+## 5. 查询写法检查
+
+推荐写法：
+
+```sql
+SELECT id
+FROM items
+ORDER BY embedding <=> '[...]'
+LIMIT 10;
+```
+
+高风险写法：
+
+```sql
+ORDER BY embedding <=> '[...]', id
+```
+
+原因：二级排序可能导致 IVFFlat 不能被选中，查询退化为 `Seq Scan + Sort`。
+
+必须用 `EXPLAIN` 验证：
+
+```text
+Index Scan using ... ivfflat ...
+```
+
+## 6. 低召回处理
+
+如果 recall 低：
+
+1. 增大 `ivfflat.probes`。
+2. 检查 `lists` 是否过大导致每个 list 数据太少。
+3. 对 Cosine/IP 场景检查向量是否需要归一化。
+4. 使用 clustered/skewed 数据集做负向测试。
+5. 对比 exact scan，确认评估逻辑正确。
+
+## 7. 构建失败处理
+
+如果出现类似内存不足：
+
+```text
+memory required is ... maintenance_work_mem is ...
+```
+
+处理顺序：
+
+1. 使用 `diagnose_ivfflat_build` 估算所需内存。
+2. 临时提高 `maintenance_work_mem`。
+3. 降低 `lists`。
+4. 分批导入数据后重建索引。
+5. 避免多个大 IVFFlat 索引并发构建。
+
+## 8. 日志与磁盘
+
+建议配置：
+
+```text
+logging_collector = on
+log_rotation_size = '100MB'
+log_truncate_on_rotation = on
+```
+
+检查命令：
+
+```bash
+df -h /
+du -sh /var/log/opentenbase/* 2>/dev/null || true
+```
+
+## 9. 上线前验收
+
+| 项目 | 通过标准 |
+| --- | --- |
+| extension | `CREATE EXTENSION vector` 成功 |
+| index build | IVFFlat 索引构建成功，无内存错误 |
+| plan | 查询走 IVFFlat Index Scan |
+| recall | 满足业务目标 |
+| latency | avg/p95/p99 满足预算 |
+| logs | 日志轮转启用，磁盘无异常增长 |
+| rollback | 可删除索引或切换 exact scan |
+

--- a/patches/pgvector-ivfflat-diagnostics-tools.patch
+++ b/patches/pgvector-ivfflat-diagnostics-tools.patch
@@ -1,0 +1,201 @@
+diff --git a/contrib/pgvector/bench/ivfflat_diagnostics.sql b/contrib/pgvector/bench/ivfflat_diagnostics.sql
+new file mode 100644
+index 0000000..92d600b
+--- /dev/null
++++ b/contrib/pgvector/bench/ivfflat_diagnostics.sql
+@@ -0,0 +1,195 @@
++\set ON_ERROR_STOP on
++
++CREATE SCHEMA IF NOT EXISTS pgvector_bench;
++
++CREATE OR REPLACE FUNCTION pgvector_bench.parse_memory_mb(value text)
++RETURNS numeric
++LANGUAGE plpgsql
++AS $$
++DECLARE
++    cleaned text;
++    amount numeric;
++    unit text;
++BEGIN
++    IF value IS NULL OR btrim(value) = '' THEN
++        RETURN NULL;
++    END IF;
++
++    cleaned := lower(regexp_replace(btrim(value), '\s+', '', 'g'));
++    amount := substring(cleaned from '^[0-9]+[.]?[0-9]*')::numeric;
++    unit := regexp_replace(cleaned, '^[0-9]+[.]?[0-9]*', '');
++
++    IF unit IN ('', 'mb') THEN
++        RETURN amount;
++    ELSIF unit IN ('kB', 'kb') THEN
++        RETURN amount / 1024.0;
++    ELSIF unit = 'gb' THEN
++        RETURN amount * 1024.0;
++    ELSIF unit = 'tb' THEN
++        RETURN amount * 1024.0 * 1024.0;
++    ELSE
++        RAISE EXCEPTION 'unsupported memory unit in %', value;
++    END IF;
++END;
++$$;
++
++CREATE OR REPLACE FUNCTION pgvector_bench.estimate_ivfflat_build_memory_mb(
++    row_count bigint,
++    dims integer,
++    lists integer
++)
++RETURNS numeric
++LANGUAGE plpgsql
++AS $$
++DECLARE
++    vector_mb numeric;
++    centroid_mb numeric;
++    overhead_mb numeric;
++BEGIN
++    IF row_count <= 0 THEN
++        RAISE EXCEPTION 'row_count must be positive';
++    END IF;
++    IF dims <= 0 THEN
++        RAISE EXCEPTION 'dims must be positive';
++    END IF;
++    IF lists <= 0 THEN
++        RAISE EXCEPTION 'lists must be positive';
++    END IF;
++
++    vector_mb := row_count::numeric * dims * 4 / 1024 / 1024;
++    centroid_mb := lists::numeric * dims * 4 / 1024 / 1024;
++    overhead_mb := GREATEST(32, vector_mb * 3.0 + lists::numeric * 0.05);
++    RETURN CEIL(vector_mb + centroid_mb + overhead_mb);
++END;
++$$;
++
++CREATE OR REPLACE FUNCTION pgvector_bench.recommend_ivfflat_lists(
++    row_count bigint,
++    dims integer DEFAULT 128
++)
++RETURNS integer
++LANGUAGE plpgsql
++AS $$
++DECLARE
++    factor numeric;
++BEGIN
++    IF row_count <= 0 THEN
++        RAISE EXCEPTION 'row_count must be positive';
++    END IF;
++    IF dims <= 0 THEN
++        RAISE EXCEPTION 'dims must be positive';
++    END IF;
++
++    factor := CASE WHEN dims >= 128 THEN 3.2 ELSE 2.0 END;
++    RETURN GREATEST(10, LEAST(4096, (ROUND((SQRT(row_count::numeric) * factor) / 50.0) * 50)::integer));
++END;
++$$;
++
++CREATE OR REPLACE FUNCTION pgvector_bench.diagnose_ivfflat_build(
++    row_count bigint,
++    dims integer,
++    lists integer DEFAULT NULL,
++    probes integer DEFAULT NULL,
++    target_recall numeric DEFAULT 0.90,
++    maintenance_work_mem text DEFAULT NULL
++)
++RETURNS TABLE (
++    check_name text,
++    status text,
++    detail text,
++    recommendation text
++)
++LANGUAGE plpgsql
++AS $$
++DECLARE
++    effective_lists integer;
++    effective_probes integer;
++    estimated_mem_mb numeric;
++    configured_mem_mb numeric;
++    probe_ratio numeric;
++BEGIN
++    IF target_recall <= 0 OR target_recall > 1 THEN
++        RAISE EXCEPTION 'target_recall must be in (0, 1]';
++    END IF;
++
++    effective_lists := COALESCE(lists, pgvector_bench.recommend_ivfflat_lists(row_count, dims));
++    effective_probes := COALESCE(probes, CEIL(effective_lists * CASE
++        WHEN target_recall >= 0.99 THEN 1.00
++        WHEN target_recall >= 0.95 THEN 0.75
++        WHEN target_recall >= 0.90 THEN 0.50
++        WHEN target_recall >= 0.80 THEN 0.30
++        ELSE 0.15
++    END)::integer);
++    effective_probes := GREATEST(1, LEAST(effective_lists, effective_probes));
++    estimated_mem_mb := pgvector_bench.estimate_ivfflat_build_memory_mb(row_count, dims, effective_lists);
++    configured_mem_mb := COALESCE(
++        pgvector_bench.parse_memory_mb(maintenance_work_mem),
++        pgvector_bench.parse_memory_mb(current_setting('maintenance_work_mem'))
++    );
++    probe_ratio := effective_probes::numeric / effective_lists;
++
++    check_name := 'lists';
++    status := CASE
++        WHEN lists IS NULL THEN 'info'
++        WHEN effective_lists < 10 THEN 'risk'
++        WHEN effective_lists > row_count THEN 'risk'
++        ELSE 'ok'
++    END;
++    detail := format('rows=%s dims=%s lists=%s recommended_lists=%s', row_count, dims, COALESCE(lists, effective_lists), pgvector_bench.recommend_ivfflat_lists(row_count, dims));
++    recommendation := CASE
++        WHEN lists IS NULL THEN format('start with lists=%s and validate recall/latency with benchmark', effective_lists)
++        WHEN effective_lists > row_count THEN 'lists should not exceed row count'
++        ELSE 'lists is within the basic heuristic range; validate with workload data'
++    END;
++    RETURN NEXT;
++
++    check_name := 'maintenance_work_mem';
++    status := CASE
++        WHEN configured_mem_mb < estimated_mem_mb THEN 'risk'
++        WHEN configured_mem_mb < estimated_mem_mb * 1.25 THEN 'warn'
++        ELSE 'ok'
++    END;
++    detail := format('estimated_build_memory=%sMB configured_maintenance_work_mem=%sMB', estimated_mem_mb, ROUND(configured_mem_mb, 2));
++    recommendation := CASE
++        WHEN configured_mem_mb < estimated_mem_mb THEN format('increase maintenance_work_mem to at least %sMB or reduce lists/rows per build', estimated_mem_mb)
++        WHEN configured_mem_mb < estimated_mem_mb * 1.25 THEN 'configuration is close to the estimated requirement; keep headroom for concurrent work'
++        ELSE 'memory setting has basic headroom for this index build'
++    END;
++    RETURN NEXT;
++
++    check_name := 'probes';
++    status := CASE
++        WHEN probe_ratio < 0.05 AND target_recall >= 0.90 THEN 'risk'
++        WHEN probe_ratio < 0.10 AND target_recall >= 0.90 THEN 'warn'
++        WHEN effective_probes = effective_lists THEN 'warn'
++        ELSE 'ok'
++    END;
++    detail := format('probes=%s lists=%s probe_ratio=%s target_recall=%s', effective_probes, effective_lists, ROUND(probe_ratio, 4), target_recall);
++    recommendation := CASE
++        WHEN probe_ratio < 0.10 AND target_recall >= 0.90 THEN 'low probes may cause poor recall; benchmark higher probes such as lists*0.3, lists*0.5, and lists'
++        WHEN effective_probes = effective_lists THEN 'probes equals lists; recall should be high but latency may exceed exact scan'
++        ELSE 'probe ratio is plausible; validate using recall@k benchmark'
++    END;
++    RETURN NEXT;
++
++    check_name := 'benchmark_required';
++    status := 'info';
++    detail := 'IVFFlat quality depends on data distribution, metric, topk, and query workload';
++    recommendation := 'run bench/run_ivfflat_benchmark.sh with representative data and save CSV plus EXPLAIN plan evidence';
++    RETURN NEXT;
++END;
++$$;
++
++CREATE OR REPLACE VIEW pgvector_bench.ivfflat_index_inventory AS
++SELECT
++    ns.nspname AS schema_name,
++    tbl.relname AS table_name,
++    idx.relname AS index_name,
++    pg_relation_size(idx.oid) AS index_bytes,
++    pg_get_indexdef(idx.oid) AS index_definition,
++    CASE WHEN pg_get_indexdef(idx.oid) ILIKE '%USING ivfflat%' THEN 'ivfflat' ELSE 'other' END AS index_kind
++FROM pg_class idx
++JOIN pg_index i ON i.indexrelid = idx.oid
++JOIN pg_class tbl ON tbl.oid = i.indrelid
++JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
++WHERE pg_get_indexdef(idx.oid) ILIKE '%USING ivfflat%';

--- a/scripts/pgvector-index-diagnostics.sh
+++ b/scripts/pgvector-index-diagnostics.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DBNAME="${DBNAME:-postgres}"
+ROW_COUNT="${ROW_COUNT:-100000}"
+DIMS="${DIMS:-128}"
+LISTS="${LISTS:-}"
+PROBES="${PROBES:-}"
+TARGET_RECALL="${TARGET_RECALL:-0.90}"
+MAINTENANCE_WORK_MEM="${MAINTENANCE_WORK_MEM:-}"
+SQL_FILE="${SQL_FILE:-}"
+
+usage() {
+    cat <<USAGE
+Usage:
+  DBNAME=postgres ROW_COUNT=100000 DIMS=128 LISTS=1000 PROBES=500 \\
+    TARGET_RECALL=0.90 MAINTENANCE_WORK_MEM=512MB \\
+    SQL_FILE=/path/to/ivfflat_diagnostics.sql \\
+    $0
+
+Environment:
+  DBNAME                 target database, default: postgres
+  ROW_COUNT              vector row count, default: 100000
+  DIMS                   vector dimensions, default: 128
+  LISTS                  IVFFlat lists; empty means use recommendation heuristic
+  PROBES                 IVFFlat probes; empty means use target recall heuristic
+  TARGET_RECALL          expected recall target, default: 0.90
+  MAINTENANCE_WORK_MEM   memory setting to diagnose; empty means current DB setting
+  SQL_FILE               optional ivfflat_diagnostics.sql path to load before running
+
+Connection variables such as PGHOST, PGPORT, PGUSER and PGPASSWORD are passed
+through to psql.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+psql_cmd() {
+    psql -X -v ON_ERROR_STOP=1 -d "$DBNAME" "$@"
+}
+
+sql_literal_or_null() {
+    local value="$1"
+    if [[ -z "$value" ]]; then
+        printf 'NULL'
+    else
+        printf "'%s'" "${value//\'/\'\'}"
+    fi
+}
+
+int_or_null() {
+    local value="$1"
+    if [[ -z "$value" ]]; then
+        printf 'NULL'
+    else
+        printf '%s' "$value"
+    fi
+}
+
+if [[ -n "$SQL_FILE" ]]; then
+    psql_cmd -f "$SQL_FILE"
+fi
+
+lists_sql="$(int_or_null "$LISTS")"
+probes_sql="$(int_or_null "$PROBES")"
+mem_sql="$(sql_literal_or_null "$MAINTENANCE_WORK_MEM")"
+
+psql_cmd -c "
+SELECT check_name, status, detail, recommendation
+FROM pgvector_bench.diagnose_ivfflat_build(
+    ${ROW_COUNT},
+    ${DIMS},
+    ${lists_sql},
+    ${probes_sql},
+    ${TARGET_RECALL},
+    ${mem_sql}
+);
+"
+
+psql_cmd -c "
+SELECT schema_name, table_name, index_name, pg_size_pretty(index_bytes) AS index_size, index_kind
+FROM pgvector_bench.ivfflat_index_inventory
+ORDER BY index_bytes DESC
+LIMIT 20;
+"
+


### PR DESCRIPTION
## Summary
- add pgvector IVFFlat index build diagnostics SQL patch
- add reusable pgvector index diagnostics runner script
- add project two diagnostics report, production tuning template, and AI-reproducible SOP for project one/two workflows
- record local SQL/function and script-level validation evidence

## Validation
- ran bash syntax check for scripts/pgvector-index-diagnostics.sh
- loaded ivfflat_diagnostics.sql into local PostgreSQL 14.22 for SQL/plpgsql function validation
- verified parse_memory_mb, recommend_ivfflat_lists, estimate_ivfflat_build_memory_mb, and diagnose_ivfflat_build
- verified low-memory/low-probes case returns risk and 512MB/probes=500 case returns ok

## Notes
- CloudStudio OpenTenBase SSH endpoint is currently closing connections before command execution, so OpenTenBase remote validation commands are documented in the report and should be rerun when the remote environment is reachable.