### PR TITLE
fix(setup-rpm): 支持 OpenCloudOS/Anolis 等 RHEL 兼容发行版 + ID_LIKE 兜底

### DIFF
--- a/scripts/setup-rpm.sh
+++ b/scripts/setup-rpm.sh
@@ -70,7 +70,11 @@ detect_os() {
     . /etc/os-release
 
     case "$ID" in
-        rocky|almalinux|centos|rhel)
+        rocky|almalinux|centos|rhel|opencloudos|anolis|tencentos)
+            # RHEL-compatible distros. The last three (OpenCloudOS, Anolis OS,
+            # TencentOS) are RHEL 8/9 compatible but their ID was missing from
+            # the original whitelist, causing a hard exit on otherwise working
+            # systems. They use the same el8/el9 repo subdirectory.
             case "$VERSION_ID" in
                 8*|9*)
                     REPO_SUBDIR="el${VERSION_ID%%.*}"
@@ -88,9 +92,22 @@ detect_os() {
             REPO_SUBDIR="openeuler"
             ;;
         *)
-            log_error "Unsupported distribution: $ID"
-            echo "Supported: Rocky Linux 8/9, AlmaLinux 8/9, CentOS Stream 8/9, Fedora 40+, openEuler 22.03+, Huawei Cloud EulerOS"
-            exit 1
+            # Fallback for unknown IDs whose /etc/os-release exposes an
+            # ID_LIKE indicating RHEL/fedora lineage (e.g. future distros).
+            # This avoids a hard exit on RHEL-compatible systems we have not
+            # explicitly listed above.
+            if echo "$ID_LIKE" | grep -qiE "rhel|fedora|centos"; then
+                case "$VERSION_ID" in
+                    8*) REPO_SUBDIR="el8" ;;
+                    9*) REPO_SUBDIR="el9" ;;
+                    *)  log_warn "$ID $VERSION_ID untested (ID_LIKE=$ID_LIKE), using el9 repo"; REPO_SUBDIR="el9" ;;
+                esac
+                log_warn "$ID is not in the tested list but ID_LIKE=$ID_LIKE; using $REPO_SUBDIR repo (untested)"
+            else
+                log_error "Unsupported distribution: $ID"
+                echo "Supported: Rocky Linux 8/9, AlmaLinux 8/9, CentOS Stream 8/9, Fedora 40+, openEuler 22.03+, Huawei Cloud EulerOS, OpenCloudOS 8/9, Anolis OS 8/9"
+                exit 1
+            fi
             ;;
     esac
 


### PR DESCRIPTION
## 问题

`setup-rpm.sh` 的 `detect_os()` 用 `case "$ID"` 硬编码了 7 个发行版 ID 白名单，任何 RHEL 兼容但 ID 不在白名单的发行版（OpenCloudOS、Anolis OS、TencentOS 等）命中 `*)` 分支直接 `exit 1`，即使 el8/el9 包在这些系统上完全可用。实测在 OpenCloudOS 9 上执行 `setup-rpm.sh` 直接报错退出。

## 根因

- `detect_os()` 只认 `/etc/os-release` 的 `ID` 字段，未利用 `ID_LIKE` 判断发行版血统
- 与 `setup-apt.sh` 策略不一致：APT 脚本对未测试版本只 log_warn 继续，RPM 脚本对未知发行版直接 exit 1

## 修复方案（双层加固）

1. 显式加入 `opencloudos|anolis|tencentos` 到 RHEL 系 case，按 VERSION_ID 映射 el8/el9
2. 增加 `ID_LIKE` 兜底：ID 未知但 ID_LIKE 含 rhel|fedora|centos 时，按 VERSION_ID 推导 el8/el9 并 log_warn 继续，而非硬退出。对未来新 RHEL 兼容发行版自动适配

## 测试

15 组模拟 os-release 数据验证 detect_os 逻辑全部通过：OpenCloudOS 8/9、Anolis 8/9、TencentOS、Rocky、Alma、CentOS、Fedora、openEuler、未知ID+ID_LIKE rhel/centos（兜底成功）、Ubuntu/Debian（正确拒绝）、未知ID无ID_LIKE（正确拒绝）。

## 改动范围

仅 `scripts/setup-rpm.sh` 的 `detect_os()` 函数，+21 -4，不影响 GPG 校验、repo 配置等其他逻辑。对原有 7 个白名单发行版行为零变化。