### PR TITLE
fix(repo): 签名包本身（不只元数据），从根源解决 GPG 安装失败

### DIFF
--- a/.github/workflows/deploy-repo.yml
+++ b/.github/workflows/deploy-repo.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq dpkg-dev gnupg jq createrepo-c
+          sudo apt-get install -y -qq dpkg-dev gnupg jq createrepo-c rpm-sign dpkg-sig
 
       - name: Import GPG key
         env:

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -578,6 +578,64 @@ DOWNLOAD_DIR=$(mktemp -d)
 trap 'rm -rf "$DOWNLOAD_DIR"' EXIT
 download_release "$TAG" "$DOWNLOAD_DIR"
 
+# Sign downloaded packages (package-level GPG signature, not just repo metadata)
+# This is required for gpgcheck=1 in the repo config to work — without package
+# signatures, dnf/apt reject installation even though repomd.xml is signed.
+sign_downloaded_packages() {
+    local dir="$1"
+
+    if [ "$NO_SIGN" = "true" ]; then
+        log_warn "Skipping package signing (--no-sign)"
+        return 0
+    fi
+
+    if ! command -v gpg &>/dev/null; then
+        log_warn "gpg not available, packages will be unsigned"
+        return 0
+    fi
+
+    # Verify the signing key is available
+    if ! gpg --list-secret-keys "$GPG_KEY_ID" &>/dev/null; then
+        log_warn "GPG key $GPG_KEY_ID not in keyring, packages will be unsigned"
+        return 0
+    fi
+
+    local rpm_count deb_count
+    rpm_count=$(find "$dir" -name '*.rpm' 2>/dev/null | wc -l)
+    deb_count=$(find "$dir" -name '*.deb' 2>/dev/null | wc -l)
+    log_info "Signing $rpm_count RPM + $deb_count DEB packages ..."
+
+    # Sign RPM packages with rpmsign
+    if [ "$rpm_count" -gt 0 ]; then
+        if command -v rpmsign &>/dev/null; then
+            find "$dir" -name '*.rpm' -print0 | while IFS= read -r -d '' rpm; do
+                rpmsign --addsign --define "_gpg_name $GPG_KEY_ID" "$rpm" 2>/dev/null \
+                    && log_info "  Signed: $(basename "$rpm")" \
+                    || log_warn "  Sign failed: $(basename "$rpm")"
+            done
+        else
+            log_warn "rpmsign not available, RPM packages will be unsigned"
+        fi
+    fi
+
+    # Sign DEB packages with dpkg-sig
+    if [ "$deb_count" -gt 0 ]; then
+        if command -v dpkg-sig &>/dev/null; then
+            find "$dir" -name '*.deb' -print0 | while IFS= read -r -d '' deb; do
+                dpkg-sig --sign builder -k "$GPG_KEY_ID" "$deb" 2>/dev/null \
+                    && log_info "  Signed: $(basename "$deb")" \
+                    || log_warn "  Sign failed: $(basename "$deb")"
+            done
+        else
+            log_warn "dpkg-sig not available, DEB packages will be unsigned"
+        fi
+    fi
+
+    log_info "Package signing complete"
+}
+
+sign_downloaded_packages "$DOWNLOAD_DIR"
+
 # Build repos
 if [ "$BUILD_APT" = "true" ]; then
     build_apt_repo "$DOWNLOAD_DIR" "$OUTPUT_DIR"


### PR DESCRIPTION
## 问题

安装 OpenTenBase 时 dnf 报 GPG 校验失败，必须 --nogpgcheck 才能装。

## 根因

build-repo.sh 只签 repomd.xml（repo 元数据），不签 .rpm/.deb 包本身。但 setup-rpm.sh 配了 gpgcheck=1——检查每个包的签名，不签元数据。包没签名 → dnf 拒绝安装。

release.yml 构建时用 sign-packages.sh 签包，但 6月2日的 release 跑时 GPG_PRIVATE_KEY secret 还没配（6月6日才配），所以发布的包全没签名。deploy-repo.yml 重建 repo 时也不签包。

## 修复

1. build-repo.sh 加 sign_downloaded_packages()：download_release 后、build 前用 rpmsign --addsign 签 .rpm、dpkg-sig 签 .deb
2. deploy-repo.yml 依赖加 rpm-sign 和 dpkg-sig

合并后手动触发 deploy-repo workflow，repo 上的包就有签名了。