### PR TITLE
fix(deploy-repo): 修正签名工具包名（rpm-sign→rpm, dpkg-sig→debsigs）

### DIFF
--- a/.github/workflows/deploy-repo.yml
+++ b/.github/workflows/deploy-repo.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq dpkg-dev gnupg jq createrepo-c rpm-sign dpkg-sig
+          sudo apt-get install -y -qq dpkg-dev gnupg jq createrepo-c rpm debsigs
 
       - name: Import GPG key
         env:

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -618,16 +618,16 @@ sign_downloaded_packages() {
         fi
     fi
 
-    # Sign DEB packages with dpkg-sig
+    # Sign DEB packages with debsigs
     if [ "$deb_count" -gt 0 ]; then
-        if command -v dpkg-sig &>/dev/null; then
+        if command -v debsigs &>/dev/null; then
             find "$dir" -name '*.deb' -print0 | while IFS= read -r -d '' deb; do
-                dpkg-sig --sign builder -k "$GPG_KEY_ID" "$deb" 2>/dev/null \
+                debsigs --sign=origin -k "$GPG_KEY_ID" "$deb" 2>/dev/null \
                     && log_info "  Signed: $(basename "$deb")" \
                     || log_warn "  Sign failed: $(basename "$deb")"
             done
         else
-            log_warn "dpkg-sig not available, DEB packages will be unsigned"
+            log_warn "debsigs not available, DEB packages will be unsigned"
         fi
     fi
 


### PR DESCRIPTION
PR #31 用了 rpm-sign 和 dpkg-sig，但这两个包在 Ubuntu 24.04 runner 上不存在，导致 deploy-repo workflow 安装依赖失败。改用 rpm（含 rpmsign）和 debsigs，build-repo.sh 的 DEB 签名同步改为 debsigs --sign=origin。