### PR TITLE
fix: GTM crashes on low-core (≤2) machines — auto LD_PRELOAD shim

### DIFF
--- a/config/opentenbase-ctl
+++ b/config/opentenbase-ctl
@@ -76,8 +76,32 @@ cmd_init() {
         # Override port
         sed -i "s/^port =.*/port = $GTM_PORT/" "$GTM_PGDATA/gtm.conf"
         sed -i "s/^nodename =.*/nodename = 'gtm_master'/" "$GTM_PGDATA/gtm.conf"
-        # 注意：不追加 gtm_thread_count，该参数不被 GTM 二进制识别，会导致配置解析失败
-        # 如果遇到 "binding threads failed" 错误，请手动编辑 gtm.conf 设置线程数
+        # Build CPU-affinity shim for low-core machines (<= 2 cores).
+        # GTM's bind_service_threads() loops from cpu=2 to nproc-1; when nproc<=2
+        # the loop body never executes, leaving an empty cpu_set_t.  This causes
+        # pthread_setaffinity_np to return EINVAL and GTM crashes at startup.
+        # The shim overrides pthread_setaffinity_np to a no-op.
+        local _cpu_cores
+        _cpu_cores=$(nproc 2>/dev/null || echo "2")
+        if [ "$_cpu_cores" -le 2 ] && command -v gcc >/dev/null 2>&1; then
+            local _shim="${OTB_HOME}/lib/noaffinity.so"
+            if [ ! -f "$_shim" ]; then
+                mkdir -p "${OTB_HOME}/lib"
+                local _src
+                _src=$(mktemp /tmp/noaffinity_XXXXXX.c)
+                cat > "$_src" <<'SHIMC'
+#define _GNU_SOURCE
+#include <sched.h>
+#include <pthread.h>
+int pthread_setaffinity_np(pthread_t t, size_t s, const cpu_set_t *c) { return 0; }
+SHIMC
+                if gcc -shared -fPIC -o "$_shim" "$_src" 2>/dev/null; then
+                    chmod 755 "$_shim"
+                    echo ">> Built CPU-affinity shim for ${_cpu_cores}-core machine"
+                fi
+                rm -f "$_src"
+            fi
+        fi
     else
         echo ">> gtm already initialised, skipping"
     fi
@@ -167,7 +191,13 @@ start_gtm() {
         return 0
     fi
     echo "  starting gtm"
-    run_as_otb "$OTB_BIN/gtm_ctl" -Z gtm -D "$GTM_PGDATA" -l "$GTM_LOG" start
+    local _shim="${OTB_HOME}/lib/noaffinity.so"
+    if [ -f "$_shim" ]; then
+        echo "  (using CPU-affinity shim: $(nproc) cores)"
+        LD_PRELOAD="$_shim" run_as_otb "$OTB_BIN/gtm_ctl" -Z gtm -D "$GTM_PGDATA" -l "$GTM_LOG" start
+    else
+        run_as_otb "$OTB_BIN/gtm_ctl" -Z gtm -D "$GTM_PGDATA" -l "$GTM_LOG" start
+    fi
     wait_for_port "$GTM_PORT" || { echo "gtm port $GTM_PORT not listening"; return 1; }
 }
 

--- a/docs/06-best-practices.md
+++ b/docs/06-best-practices.md
@@ -20,7 +20,9 @@
 
 **注意事项：**
 - GTM 线程数不能超过 CPU 核心数，避免 `binding threads failed` 错误
-- 使用 `nproc` 检查核心数，动态配置 `thread_count`（注意：`gtm_thread_count` 不是合法参数）
+- 在 ≤2 核的机器上，GTM 的 `bind_service_threads()` 会生成空 cpuset 导致 `pthread_setaffinity_np` 返回 EINVAL
+- `opentenbase-ctl` 会自动检测并编译 CPU-affinity shim（`noaffinity.so`）来绕过此问题
+- 使用 `nproc` 检查核心数
 
 ```bash
 # 检测 CPU 核心数

--- a/scripts/opentenbase-ctl
+++ b/scripts/opentenbase-ctl
@@ -237,11 +237,10 @@ cmd_init() {
         fi
     done
 
-    # Detect CPU cores and set GTM thread count
+    # Detect CPU cores
     local cpu_cores
     cpu_cores=$(nproc 2>/dev/null || echo "2")
-    local gtm_threads=$((cpu_cores < 4 ? cpu_cores : 4))
-    log_info "Detected ${cpu_cores} CPU cores, GTM threads: ${gtm_threads}"
+    log_info "Detected ${cpu_cores} CPU cores"
 
     # Detect available RAM and auto-tune memory settings
     # OpenTenBase pooler cache requires ~1GB+ non-swappable shared memory per node
@@ -281,6 +280,38 @@ cmd_init() {
     # Configure GTM
     sed -i "s/^port =.*/port = ${GTM_PORT}/" "${data}/gtm/gtm.conf"
     sed -i "s/^nodename =.*/nodename = 'gtm_master'/" "${data}/gtm/gtm.conf"
+
+    # Build CPU-affinity shim for low-core machines (<= 2 cores).
+    # GTM's bind_service_threads() loops from cpu=2 to nproc-1; when nproc<=2
+    # the loop body never executes, leaving an empty cpu_set_t.  Passing an
+    # empty set to pthread_setaffinity_np returns EINVAL (22), which GTM
+    # treats as FATAL during startup and exits immediately.
+    # The shim overrides pthread_setaffinity_np to a no-op so GTM starts
+    # without CPU pinning — acceptable for dev/test on small VMs.
+    if [[ "$cpu_cores" -le 2 ]]; then
+        local shim="${OT_BASE}/${ver}/lib/noaffinity.so"
+        if [[ ! -f "$shim" ]] && command -v gcc >/dev/null 2>&1; then
+            mkdir -p "${OT_BASE}/${ver}/lib"
+            local _src
+            _src=$(mktemp /tmp/noaffinity_XXXXXX.c)
+            cat > "$_src" <<'SHIMC'
+#define _GNU_SOURCE
+#include <sched.h>
+#include <pthread.h>
+int pthread_setaffinity_np(pthread_t t, size_t s, const cpu_set_t *c) { return 0; }
+SHIMC
+            if gcc -shared -fPIC -o "$shim" "$_src" 2>/dev/null; then
+                chmod 755 "$shim"
+                log_ok "Built CPU-affinity shim for ${cpu_cores}-core machine"
+            else
+                log_warn "Failed to build affinity shim; GTM may crash on this ${cpu_cores}-core machine"
+            fi
+            rm -f "$_src"
+        elif [[ ! -f "$shim" ]]; then
+            log_warn "${cpu_cores} CPU cores detected but gcc not available to build affinity shim"
+            log_warn "GTM may fail with 'binding threads failed' error"
+        fi
+    fi
 
     # Initialize Datanode (with --master_gtm_* flags for GTM connection)
     log_info "Initializing Datanode..."
@@ -505,7 +536,13 @@ cmd_start() {
     # Start GTM
     if ! check_port "$GTM_PORT"; then
         log_info "Starting GTM..."
-        as_svc "$svc_user" "${bin}/gtm_ctl start -D ${data}/gtm -Z gtm -l ${log}/gtm.log" || {
+        local _preload=""
+        local _shim="${OT_BASE}/${ver}/lib/noaffinity.so"
+        if [[ -f "$_shim" ]]; then
+            log_info "Using CPU-affinity shim ($(nproc 2>/dev/null || echo '?') cores)"
+            _preload="LD_PRELOAD=${_shim} "
+        fi
+        as_svc "$svc_user" "${_preload}${bin}/gtm_ctl start -D ${data}/gtm -Z gtm -l ${log}/gtm.log" || {
             log_error "GTM start failed"
             exit 1
         }


### PR DESCRIPTION
## Problem

GTM crashes with `FATAL: binding threads failed for 22` on machines with ≤ 2 CPU cores.

### Root cause

GTM's `bind_service_threads()` ([main.c](https://github.com/OpenTenBase/OpenTenBase/blob/master/src/gtm/main/main.c)) loops from `cpu=2` to `nproc-1`:

```c
void bind_service_threads(void) {
    int cpu_num = get_nprocs();
    for(cpu = 2; cpu < cpu_num; cpu++) {
        CPU_SET(cpu, &cpuset);
    }
    bind_thread_to_cores(cpuset);  // empty cpuset when nproc ≤ 2
}
```

When `nproc ≤ 2`, the loop body never executes, leaving an empty `cpu_set_t`. Passing this to `pthread_setaffinity_np` returns `EINVAL` (22), which GTM treats as FATAL during startup.

### Error log

```
LOG:  Started to run as GTM-Active.
LOG:  Processors do not support nonstop tsc
LOG:  constant and nonstop TSC is needed.
FATAL:  binding threads failed for 22
```

## Fix

Auto-detect `nproc ≤ 2` during `opentenbase-ctl init`, compile a tiny LD_PRELOAD shim (`noaffinity.so`) that overrides `pthread_setaffinity_np` to a no-op, and inject it via `LD_PRELOAD` when starting GTM.

### Changes

- **`scripts/opentenbase-ctl`**: Build shim in `cmd_init()`, use `LD_PRELOAD` in `cmd_start()`
- **`config/opentenbase-ctl`**: Same fix in the alternative config version
- **`docs/06-best-practices.md`**: Updated documentation

## Verification

Tested on OpenCloudOS 9.4 (2 vCPU, 7.6 GB RAM):

```
[INFO] Detected 2 CPU cores
[OK] Built CPU-affinity shim for 2-core machine
[INFO] Starting GTM...
[INFO] Using CPU-affinity shim (2 cores)
[OK] GTM started (port 6666)
[OK] Datanode started (port 15432)
[OK] Coordinator started (port 5432)
```

All three nodes started successfully.