### PR TITLE
fix(release): 自动触发 CDN 仓库部署（Release 发布后同步 CDN）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  actions: write  # 用于触发 deploy-repo.yml（CDN 同步）
 
 jobs:
   # ============================================================
@@ -237,3 +238,14 @@ jobs:
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "curl -sSL https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/releases/download/${{ steps.version.outputs.tag }}/install.sh | sudo bash" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger CDN deploy
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering CDN deploy for ${{ steps.version.outputs.tag }}..."
+          gh workflow run "Deploy APT/RPM Repository to GitHub Pages" \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            --field tag="${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## 问题

当 `release.yml` 推送 tag 创建 Release 后，由于 GitHub Actions 的安全限制，**默认的 `GITHUB_TOKEN` 无法触发** `on: release: [published]` 事件，导致 `deploy-repo.yml` 不会自动运行，CDN 仓库同步停滞。

## 修复

在 `release.yml` 的 `release` job 末尾增加一步 `Trigger CDN deploy`，通过 `gh workflow run` **显式触发** `deploy-repo.yml`：

```yaml
- name: Trigger CDN deploy
  if: github.event_name != 'workflow_dispatch'
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    gh workflow run "Deploy APT/RPM Repository to GitHub Pages" \
      --repo "${{ github.repository }}" \
      --ref main \
      --field tag="${{ steps.version.outputs.tag }}"
```

- **`if: github.event_name != 'workflow_dispatch'`**：手动触发时不再重复触发 CDN 部署（避免嵌套调用）
- 补充了 `permissions.actions: write` 以允许 `gh workflow run`

## 效果

之后每次 tag push 自动发布 Release 后，CDN 仓库（`repo.blackevil217.com`）会自动同步更新。

Closes #(issue)
