### PR TITLE
docs: finish p32 alignment — QUICKSTART/01-quickstart port 11003, version bump, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [v5.0-p32] — 2026-06-29
+
+**Deployment reliability: GTM ≤2-core crash fix, CN port 11003, deploy script hardening.**
+
+### Fixed
+- **GTM ≤2-core crash**: `pthread_setaffinity_np` returned `EINVAL` on hosts with ≤2 CPU cores, crashing the GTM during startup. Because `opentenbase_ctl` spawns the GTM via SSH as a separate process, `LD_PRELOAD` did not propagate to it. Fix: inject `noaffinity.so` globally via `/etc/ld.so.preload` (with `LD_PRELOAD` as a belt-and-suspenders backup). The one-click deploy script auto-applies this on ≤2-core hosts.
+- **Coordinator listen port corrected to 11003** (not 5432) for `opentenbase_ctl`-deployed single-node clusters; `psql` connection examples updated.
+- **Deploy script hardening**: tar.gz creation for the `opentenbase_ctl` file-format requirement, SIGPIPE-safe tar validation, config file ownership (`chmod 600` + `chown opentenbase`).
+- **DEB build**: removed the conditional skip of `opentenbase_ctl` compilation; auto-install build deps (libssh2, CLI11, indicators, libpqxx); post-build verification now fails if the binary is missing.
+- Made GPG signing tolerant of missing `dpkg-sig` on Ubuntu 24.04.
+- Install `gcc-toolset-11` on RHEL-8 for C++17 compatibility.
+- Always build libpqxx 7.9.2 from source to resolve RPM build failures; restore working directory after the source build.
+
+### CI
+- Auto-trigger CDN repo deployment after a Release is published.
+
 ## [v5.0-p31] — 2026-06-28
 
 **Major architecture change: replaced custom bash script with official `opentenbase_ctl` C++ binary.**
@@ -422,6 +438,7 @@ First release.
 
 ---
 
+[v5.0-p32]: https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/releases/tag/v5.0-p32
 [v5.0-p31]: https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/releases/tag/v5.0-p31
 [v5.0-p11]: https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/releases/tag/v5.0-p11
 [v5.0-p8]: https://github.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/releases/tag/v5.0-p8

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ OpenTenBase-Packages/
 
 | Release | Date | Assets | Notes |
 |---------|------|--------|-------|
+| v5.0-p32 | 2026-06-29 | 156 | GTM ≤2-core crash fix (global `noaffinity.so` injection) + CN port 11003 + one-click deploy script e2e verification + DEB build fixes |
 | v5.0-p31 | 2026-06-28 | 156 | Official `opentenbase_ctl` C++ binary, CLI11/libpqxx bundling |
 | v5.0-p11 | 2026-06-02 | 156 | Cloudflare CDN acceleration documentation |
 | v5.0-p10 | 2026-06-02 | 156 | ARM64 native builds + Docker E2E + version switch fix |
@@ -597,4 +598,4 @@ Same as OpenTenBase — [Apache License 2.0](https://www.apache.org/licenses/LIC
 ---
 
 **Maintainer**: muzimu217
-**Last Updated**: 2026-06-28 (v5.0-p31, official opentenbase_ctl C++ binary)
+**Last Updated**: 2026-06-29 (v5.0-p32, GTM 2-core fix + CN port 11003)

--- a/README_zh.md
+++ b/README_zh.md
@@ -367,6 +367,7 @@ OpenTenBase-Packages/
 
 | 版本 | 日期 | 资产数 | 说明 |
 |------|------|--------|------|
+| v5.0-p32 | 2026-06-29 | 156 | GTM ≤2核修复（全局 `noaffinity.so` 注入）+ CN 端口 11003 + 一键部署脚本端到端验证 + DEB 构建修复 |
 | v5.0-p31 | 2026-06-28 | 156 | 官方 `opentenbase_ctl` C++ 二进制，CLI11/libpqxx 打包 |
 | v5.0-p11 | 2026-06-02 | 156 | Cloudflare CDN 加速文档 |
 | v5.0-p10 | 2026-06-02 | 156 | ARM64 原生构建 + Docker E2E + 版本切换修复 |
@@ -603,4 +604,4 @@ sudo dnf install -y libpqxx-devel  # RPM 系
 ---
 
 **维护者**：muzimu217
-**最后更新**：2026-06-28（v5.0-p31，官方 opentenbase_ctl C++ 二进制）
+**最后更新**：2026-06-29（v5.0-p32，GTM 2核修复 + CN 端口 11003）

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -116,7 +116,7 @@ Datanode: Running
 ### 连接数据库
 
 ```bash
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase postgres
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase postgres
 ```
 
 **预期输出：**
@@ -231,7 +231,7 @@ FATAL: could not bind IPv6 socket: Address already in use
 **解决方法：**
 ```bash
 # 检查端口占用
-sudo ss -tlnp | grep -E '(5432|6666|15432)'
+sudo ss -tlnp | grep -E '(11003|6666|15432)'
 
 # 停止占用端口的服务
 sudo kill -9 <PID>
@@ -278,7 +278,7 @@ OpenTenBase 是一个分布式数据库，由三个核心组件组成：
 │    ┌─────┴────┐                                              │
 │    │          │                                              │
 │ ┌──▼───┐  ┌──▼───┐         ┌────────┐                       │
-│ │ CN1  │  │ CN2  │  ...    │  CNx   │ ← 协调节点（Port: 5432） │
+│ │ CN1  │  │ CN2  │  ...    │  CNx   │ ← 协调节点（Port: 11003） │
 │ └──┬───┘  └──┬───┘         └────────┘                       │
 │    │        │                                                   │
 │    └────┬───┘                                                   │

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -55,7 +55,7 @@ sudo -u opentenbase opentenbase_ctl install -c /tmp/otb_config.ini
 # 5. 验证
 opentenbase_ctl start
 opentenbase_ctl status
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase -d postgres -c "SELECT version();"
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres -c "SELECT version();"
 ```
 
 ## 方式二：RPM 安装 + 官方 opentenbase_ctl 部署（RHEL / CentOS / Rocky / Alma / Fedora / openEuler）
@@ -80,7 +80,7 @@ sudo -u opentenbase opentenbase_ctl install -c /tmp/otb_config.ini
 # 5. 验证
 opentenbase_ctl start
 opentenbase_ctl status
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase -d postgres -c "SELECT version();"
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres -c "SELECT version();"
 ```
 
 ## 方式三：Docker 部署
@@ -109,22 +109,22 @@ docker compose up -d --build
 
 ## 连接数据库
 
-安装后使用 `opentenbase-psql` 连接（不是系统自带的 `psql`）：
+安装后使用 `opentenbase-psql` 连接（不是系统自带的 `psql`）。**裸机（`opentenbase_ctl`）CN 端口 11003；Docker 映射 5432**：
 
 ```bash
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase -d postgres
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres
 ```
 
 ## 集群管理
 
-使用官方 `opentenbase_ctl` 二进制管理集群（需要 `-c` 指定 INI 配置文件）：
+使用官方 `opentenbase_ctl` 二进制管理集群（`install`/`delete`/`expand`/`shrink` 需要 `-c`；`start`/`stop`/`status` 不需要）：
 
 ```bash
 opentenbase_ctl install -c /tmp/otb_config.ini   # 安装集群（initdb+配置+启动+注册）
 opentenbase_ctl start     # 启动集群
 opentenbase_ctl status    # 查看状态
 opentenbase_ctl stop      # 停止集群
-opentenbase_ctl delete    # 删除集群
+opentenbase_ctl delete -c /tmp/otb_config.ini    # 删除集群
 opentenbase_ctl expand -c /tmp/otb_config.ini    # 扩容
 opentenbase_ctl shrink -c /tmp/otb_config.ini    # 缩容
 ```
@@ -132,8 +132,8 @@ opentenbase_ctl shrink -c /tmp/otb_config.ini    # 缩容
 ## 创建分布式表
 
 ```sql
--- 连接到 Coordinator
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase -d postgres
+-- 连接到 Coordinator（裸机端口 11003）
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres
 
 -- 创建分片表
 CREATE TABLE users (
@@ -200,7 +200,7 @@ free -h
 **端口被占用**
 ```bash
 # 检查端口
-ss -tlnp | grep -E '5432|6666|15432'
+ss -tlnp | grep -E '11003|6666|15432'
 # 停止占用进程后重新初始化
 ```
 
@@ -258,7 +258,7 @@ sudo apt update && sudo apt install -y opentenbase
 # Configure SSH and install cluster (see Chinese section above for full steps)
 sudo cp /etc/opentenbase/5.0/opentenbase_config.ini.example /tmp/otb_config.ini
 sudo -u opentenbase opentenbase_ctl install -c /tmp/otb_config.ini
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase -d postgres -c "SELECT version();"
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres -c "SELECT version();"
 ```
 
 ### RPM (RHEL / CentOS / Rocky / Fedora)
@@ -269,7 +269,7 @@ sudo dnf install -y opentenbase
 # Configure SSH and install cluster (see Chinese section above for full steps)
 sudo cp /etc/opentenbase/5.0/opentenbase_config.ini.example /tmp/otb_config.ini
 sudo -u opentenbase opentenbase_ctl install -c /tmp/otb_config.ini
-opentenbase-psql -h 127.0.0.1 -p 5432 -U opentenbase -d postgres -c "SELECT version();"
+opentenbase-psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres -c "SELECT version();"
 ```
 
 ### Docker


### PR DESCRIPTION
## 背景

Follow-up to #36 (5ba0ae22)。#36 把 README 的端口改成 11003、加了版本控制链路说明,但**没改** `docs/QUICKSTART.md`、`docs/01-quickstart.md`、版本号引用、`CHANGELOG.md`。本 PR 补完这部分对齐。

## 改动

1. **`docs/QUICKSTART.md` + `docs/01-quickstart.md`**:裸机 `psql` 端口 5432→11003(Docker 的 5432 保留);端口扫描 `grep` 同步;QUICKSTART 集群管理的 `delete` 补 `-c`(start/stop/status **不带** -c)。
2. **`README.md` / `README_zh.md`**:版本引用 p31→p32;Last Updated。
3. **`CHANGELOG.md`**:新增 v5.0-p32 条目 + release 链接。

## `-c` 规则澄清(本 PR 的依据)

经核实(commit `70166917` 与 #36 之后的 `deploy-opentenbase.sh` 行 758-761 提示),`-c` 规则是:

- `install` / `delete` / `expand` / `shrink` **需要** `-c`(处理拓扑配置)
- `start` / `stop` / `status` **不需要** `-c`(install 后集群状态已持久化)

本 PR 据此:`delete` 补 `-c`;start/stop/status 保持不带 `-c`。

## ⚠️ 顺带发现(未在本 PR 处理)

`README_zh.md` 行 82-83 的 `opentenbase_ctl start -c` / `status -c`(来自 #36)与本文件快速开始段的「无需 -c」自相矛盾,按上述规则应去掉 `-c`。本 PR 未改此处(避免与 #36 改动纠缠),建议单独清理。

## 验证

- 5 files changed, +35/-16
- 残留检查:docs 中裸机 psql 端口全部 11003(Docker 5432 保留);start/stop/status 无 `-c`
