### PR TITLE
fix(repo): exclude arm64 from APT amd64 index (fixes opentenbase-server not installable)

### DIFF
--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -168,9 +168,15 @@ build_apt_repo() {
 
             mkdir -p "$binary_dir" "$component_pool"
 
-            # Find DEBs matching this codename AND version
+            # Find DEBs matching this codename AND version.
+            # IMPORTANT: exclude arm64 — the Release file declares Architectures: amd64
+            # only and we generate just binary-amd64. Letting arm64 .deb into the same
+            # pool makes dpkg-scanpackages emit an arm64 record for packages that have
+            # both arches (e.g. opentenbase-server), so amd64 hosts can't install them
+            # ("opentenbase-server (= ...) is not installable"). arm64 APT support needs
+            # a separate binary-arm64 index + Release arch declaration (future work).
             local debs
-            debs=$(find "$pkgdir" \( -name "*~${codename}_*.deb" -o -name "*.${codename}_*.deb" -o -name "*.${codename}.*.deb" \) 2>/dev/null | grep "_${version}-" || true)
+            debs=$(find "$pkgdir" \( -name "*~${codename}_*.deb" -o -name "*.${codename}_*.deb" -o -name "*.${codename}.*.deb" \) ! -name "*_arm64.deb" 2>/dev/null | grep "_${version}-" || true)
 
             if [ -z "$debs" ]; then
                 continue


### PR DESCRIPTION
## Bug

`apt install opentenbase` 在 amd64 上失败（Ubuntu 24.04 noble 实测，8GB/32核）：

```
opentenbase : Depends: opentenbase-server (= 5.0-1ubuntu1) but it is not installable
              Depends: opentenbase-client (= 5.0-1ubuntu1) but it is not going to be installed
```

一键部署脚本卡在 Step 2（装包）。影响所有 amd64 发行版（noble/jammy/focal/...）。

## 根因

`build-repo.sh` 行 173 把 **amd64+arm64+all 的 .deb 全 cp 进同一个** `pool/$component/$codename/`，却只生成 `binary-amd64` 索引（Release 声明 `Architectures: amd64`，行216）。

`dpkg-scanpackages` 扫混合 pool 时，对同时有 amd64+arm64 的包（opentenbase-server 等），在 `binary-amd64/Packages` 里产出了 **arm64** 记录：

```
Package: opentenbase-server
Architecture: arm64
Filename: pool/main/noble/opentenbase-server_5.0-1ubuntu1.noble_arm64.deb
```

而 amd64 的 server .deb 其实在 pool 里（release 有 `opentenbase-server_5.0-1ubuntu1.noble_amd64.deb`）。amd64 机器找不到可装的 server → 元包失败。

RPM 部分（行287-348）架构处理是对的（x86_64/aarch64 分目录），只有 APT 部分漏了架构分离。

## 修复

行 173 find 加 `! -name "*_arm64.deb"`，排除 arm64 .deb 进 APT pool。`binary-amd64` 索引只由 amd64+all 包生成，与 Release 声明的 `Architectures: amd64` 一致。

## 范围

- ✅ 修复 **amd64**（所有 amd64 发行版的 `apt install opentenbase`，含 noble）
- ⏭ **arm64 APT 支持**（需新增 binary-arm64 索引 + Release 声明 `amd64 arm64` + 双架构 checksums）作为后续 feature PR，不在本次范围

## 验证

合并后需 `workflow_dispatch` 触发 deploy-repo（tag `v5.0-p32`）重建 CDN，然后确认 noble amd64 索引 `opentenbase-server` = `Architecture: amd64`、`Filename: ...noble_amd64.deb`。
