### PR TITLE
fix(test): pgxc_pool_reload after CREATE so INSERT doesn't hit stale pool

### DIFF
--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -1034,6 +1034,12 @@ run_verification_test() {
 	fi
 	log_ok "分布式表创建成功: ${TEST_TABLE} ✓"
 
+	# CREATE 分布式表后，Coordinator 到 Datanode 的连接池需要刷新，否则紧接的
+	# INSERT 在新连接里会命中 "primary datanode connection released" 错误。
+	# pgxc_pool_reload() 让协调节点重建连接池映射，是 OpenTenBase DDL 后的标准步骤。
+	log_info "刷新连接池 (pgxc_pool_reload)..."
+	su - opentenbase -c "LD_LIBRARY_PATH=${PSQL_LIB} ${PSQL_BIN} -h 127.0.0.1 -p ${CN_PORT} -U opentenbase -d postgres -c 'SELECT pgxc_pool_reload();'" 2>&1 | grep -v "no version" || true
+
 	# 测试 4: 插入数据
 	log_info "插入测试数据..."
 	INSERT_SQL="INSERT INTO ${TEST_TABLE} VALUES (1, 'Alice', now()), (2, 'Bob', now()), (3, 'Charlie', now());"


### PR DESCRIPTION
## Problem

`opentenbase.sh test` 子命令在创建分布式表后插入数据失败：

```
[INFO] 创建分布式测试表...
CREATE TABLE
✓ 分布式表创建成功
[INFO] 插入测试数据...
WARNING:  primary datanode connection dn0001 pid ... is released, the current transaction will be aborted
ERROR:  terminating connection due to administrator command
✗ 插入数据失败
```

## Root Cause

CREATE 分布式表使用的 Coordinator→Datanode 连接在 CREATE 完成后被释放，但连接池仍缓存了该映射。紧随其后的 INSERT 开启新连接，命中被释放的 datanode backend，报连接终止。

> 注：install 主体的快速测试不受影响，因为它把 `CREATE + INSERT + SELECT` 放在单条 `psql -c`（同一连接）里执行。

## Fix

CREATE 之后、INSERT 之前调用 `SELECT pgxc_pool_reload();`，让 Coordinator 重建连接池映射（OpenTenBase DDL 后的标准步骤）。

## Verification

在 OpenCloudOS 9.4（162.14.74.145）实测：reload 后 `INSERT 0 1`，`SELECT` 正确返回数据。

## Test plan

- [x] 手动复现：CREATE 后新连接 INSERT 失败
- [x] 手动验证：加 `pgxc_pool_reload()` 后 INSERT 成功
- [ ] `curl ... | sudo bash -s -- test` 全流程通过