### PR TITLE
fix(test): sleep 2s after CREATE so datanode finishes async table creation

### DIFF
--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -1034,9 +1034,11 @@ run_verification_test() {
 	fi
 	log_ok "分布式表创建成功: ${TEST_TABLE} ✓"
 
-	# CREATE 分布式表后，Coordinator 到 Datanode 的连接池需要刷新，否则紧接的
-	# INSERT 在新连接里会命中 "primary datanode connection released" 错误。
-	# pgxc_pool_reload() 让协调节点重建连接池映射，是 OpenTenBase DDL 后的标准步骤。
+	# CREATE 分布式表是异步的：CREATE 返回时 datanode 可能尚未完成建表，
+	# 同连接立即 INSERT 会报 "relation ... does not exist"，跨连接则命中
+	# "primary datanode connection released"。留 2 秒等 datanode 落盘，再
+	# pgxc_pool_reload() 让协调节点重建连接池映射（OpenTenBase DDL 后标准步骤）。
+	sleep 2
 	log_info "刷新连接池 (pgxc_pool_reload)..."
 	su - opentenbase -c "LD_LIBRARY_PATH=${PSQL_LIB} ${PSQL_BIN} -h 127.0.0.1 -p ${CN_PORT} -U opentenbase -d postgres -c 'SELECT pgxc_pool_reload();'" 2>&1 | grep -v "no version" || true
 


### PR DESCRIPTION
## Problem

Follow-up to #41. Even with `pgxc_pool_reload()` after CREATE, the test subcommand's INSERT still failed:

```
✓ 分布式表创建成功
[INFO] 刷新连接池 (pgxc_pool_reload)...
[INFO] 插入测试数据...
ERROR:  terminating connection due to administrator command   # 跨连接
-- 或同连接 --
ERROR:  relation "public.xxx" does not exist
```

## Root Cause

`CREATE TABLE ... DISTRIBUTE BY SHARD` is **asynchronous**: the coordinator returns before the datanode has finished creating the table. `pgxc_pool_reload()`刷新了连接池映射，但 datanode 上的表还没建好，所以 INSERT 仍然失败。

## Fix

在 CREATE 与 `pgxc_pool_reload()` 之间加 `sleep 2`，等 datanode 完成建表。

## Verification

OpenCloudOS 9.4 实测：
```
CREATE TABLE  → sleep 2 → pgxc_pool_reload (t) → INSERT (COPY 3) → SELECT (3 rows)
```

## Test plan

- [x] 复现：CREATE → reload → INSERT 失败
- [x] 验证：CREATE → sleep 2 → reload → INSERT 成功
- [ ] `curl ... | sudo bash -s -- test` 全流程