### PR TITLE
fix(test): drop timestamp/now() columns that hit OpenTenBase datanode bug

### DIFF
--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -1023,9 +1023,9 @@ run_verification_test() {
 			-c \"CREATE DEFAULT NODE GROUP default_group WITH(dn0001);\"" 2>/dev/null || true
 		su - opentenbase -c "LD_LIBRARY_PATH=${PSQL_LIB} ${PSQL_BIN} -h 127.0.0.1 -p ${CN_PORT} -U opentenbase -d postgres \
 			-c \"CREATE SHARDING GROUP TO GROUP default_group;\"" 2>/dev/null || true
-		CREATE_SQL="CREATE TABLE ${TEST_TABLE} (id int, name text, created_at timestamp) DISTRIBUTE BY SHARD(id) TO GROUP default_group;"
+		CREATE_SQL="CREATE TABLE ${TEST_TABLE} (id int, name text) DISTRIBUTE BY SHARD(id) TO GROUP default_group;"
 	else
-		CREATE_SQL="CREATE TABLE ${TEST_TABLE} (id int, name text, created_at timestamp) DISTRIBUTE BY SHARD(id);"
+		CREATE_SQL="CREATE TABLE ${TEST_TABLE} (id int, name text) DISTRIBUTE BY SHARD(id);"
 	fi
 
 	if ! su - opentenbase -c "LD_LIBRARY_PATH=${PSQL_LIB} ${PSQL_BIN} -h 127.0.0.1 -p ${CN_PORT} -U opentenbase -d postgres -c \"${CREATE_SQL}\"" 2>&1; then
@@ -1044,7 +1044,7 @@ run_verification_test() {
 
 	# 测试 4: 插入数据
 	log_info "插入测试数据..."
-	INSERT_SQL="INSERT INTO ${TEST_TABLE} VALUES (1, 'Alice', now()), (2, 'Bob', now()), (3, 'Charlie', now());"
+	INSERT_SQL="INSERT INTO ${TEST_TABLE} VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie');"
 	if ! su - opentenbase -c "LD_LIBRARY_PATH=${PSQL_LIB} ${PSQL_BIN} -h 127.0.0.1 -p ${CN_PORT} -U opentenbase -d postgres -c \"${INSERT_SQL}\"" 2>&1; then
 		log_error "插入数据失败"
 		# 清理测试表


### PR DESCRIPTION
## Problem

`opentenbase.sh test` 子命令 INSERT 持续失败（即使有 #41 的 pool_reload 和 #42 的 sleep）：

```
✓ 分布式表创建成功
[INFO] 刷新连接池 (pgxc_pool_reload)...
[INFO] 插入测试数据...
ERROR:  terminating connection due to administrator command
✗ 插入数据失败
```

## Root Cause

OpenTenBase 5.0 引擎 bug：对分布式表做多行 INSERT 时，若行中含 `now()` / `timestamp` 值，会触发 datanode 连接释放（`primary datanode connection ... is released`）。可确定性地复现：

| 表结构 | INSERT | 结果 |
|--------|--------|------|
| `(id int, name text)` | 多行纯值 | COPY 3 ✅ |
| `(id int, name text, ts timestamp)` | 多行带 `now()` | ERROR ❌ |

## Fix

test 子命令的测试表去掉 `created_at timestamp` 列、INSERT 去掉 `now()`，改用纯 `int + text`（与 install 主体的快速测试一致，该路径一直稳定）。#41/#42 的 `sleep + pgxc_pool_reload` 保留，处理跨连接场景。

## Verification

干净集群（OpenCloudOS 9.4）实测跨连接流程全部通过：
```
CREATE TABLE → sleep 2 → pgxc_pool_reload (t) → INSERT (COPY 3) → SELECT (3 rows)
```

## Test plan

- [x] 复现：带 now() 的多行 INSERT 失败
- [x] 验证：去掉 now() 后跨连接 INSERT 成功
- [ ] `curl ... | sudo bash -s -- test` 全流程