### PR TITLE
Add scripts to CDN deployment for faster global access

### DIFF
--- a/.github/workflows/deploy-repo.yml
+++ b/.github/workflows/deploy-repo.yml
@@ -50,13 +50,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          chmod +x scripts/build-repo.sh
+          chmod +x scripts/tools/build-repo.sh
           TAG="$INPUT_TAG"
           if [ -z "$TAG" ]; then
-            ./scripts/build-repo.sh -o repo
+            ./scripts/tools/build-repo.sh -o repo
           else
-            ./scripts/build-repo.sh -t "$TAG" -o repo
+            ./scripts/tools/build-repo.sh -t "$TAG" -o repo
           fi
+
+          # Copy scripts to CDN for faster global access
+          echo "[INFO] Copying scripts to CDN..."
+          mkdir -p repo/scripts
+          cp scripts/opentenbase.sh repo/scripts/
+          cp scripts/setup-apt.sh repo/scripts/
+          cp scripts/setup-rpm.sh repo/scripts/
+          cp scripts/uninstall.sh repo/scripts/
+          cp scripts/switch-version.sh repo/scripts/
+          cp scripts/opentenbase-packages-key.asc repo/scripts/
+          echo "[INFO] Scripts copied to CDN successfully!"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ English | [中文](README_zh.md)
 **Blank machine → running cluster in one command.** Supports both interactive and non-interactive modes:
 
 ```bash
-# Interactive (asks a few questions, recommended for first-time users)
-curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/deploy-opentenbase.sh | sudo bash
+# CDN accelerated (recommended, global fast)
+curl -sSL https://repo.blackevil217.com/scripts/opentenbase.sh | sudo bash
+
+# GitHub direct (fallback)
+curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/opentenbase.sh | sudo bash
 
 # Non-interactive (all defaults, single-node, for CI/automation)
-curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/deploy-opentenbase.sh | sudo bash -s -- --yes
+curl -sSL https://repo.blackevil217.com/scripts/opentenbase.sh | sudo bash -s -- install --yes
 ```
 
 The script handles everything: install packages → create user → configure sshpass → path symlink → generate INI → `opentenbase_ctl install -c <config.ini>` → start, status check, and SQL verification.
@@ -94,11 +97,14 @@ opentenbase_ctl status
 ### Uninstall
 
 ```bash
-# Interactive uninstall (prompts before removing data)
+# CDN accelerated (recommended)
+curl -sSL https://repo.blackevil217.com/scripts/uninstall.sh | sudo bash
+
+# GitHub direct (fallback)
 curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/uninstall.sh | sudo bash
 
 # Full uninstall including data and logs (no prompts)
-curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/uninstall.sh | sudo bash -s -- --purge --yes
+curl -sSL https://repo.blackevil217.com/scripts/uninstall.sh | sudo bash -s -- --purge --yes
 ```
 
 ---
@@ -107,10 +113,10 @@ curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/Op
 
 The installation scripts automatically detect and use the fastest available mirror:
 
-1. **Cloudflare CDN** (`repo.blackevil217.com/apt` for APT, `repo.blackevil217.com/rpm` for RPM) — global acceleration, free forever
+1. **Cloudflare CDN** (`repo.blackevil217.com/scripts/` for scripts, `repo.blackevil217.com/apt` for APT, `repo.blackevil217.com/rpm` for RPM) — global acceleration, free forever
 2. **GitHub Pages** (`cduestc-openatom-open-source-club.github.io/OpenTenBase-Packages/`) — direct fallback
 
-> **Note**: The `curl` commands in the Quick Install section download scripts from `raw.githubusercontent.com`. Once executed, the scripts will automatically configure your system to use the CDN-accelerated repository.
+> **Recommended**: Use `https://repo.blackevil217.com/scripts/opentenbase.sh` CDN path for faster and more stable script downloads.
 
 ### China Speed Test (2026-06-02)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -44,14 +44,17 @@
 **白板机器 → 集群运行，一条命令搞定。** 支持交互式和非交互式：
 
 ```bash
-# 交互式（推荐，会问你几个问题）
-curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/deploy-opentenbase.sh | sudo bash
+# CDN 加速（推荐，全球加速）
+curl -sSL https://repo.blackevil217.com/scripts/opentenbase.sh | sudo bash
+
+# GitHub 直连（备用）
+curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/opentenbase.sh | sudo bash
 
 # 非交互式（全自动，单节点默认值，适合 CI/自动化）
-curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/deploy-opentenbase.sh | sudo bash -s -- --yes
+curl -sSL https://repo.blackevil217.com/scripts/opentenbase.sh | sudo bash -s -- install --yes
 
 # 非交互式 + 自定义参数
-sudo bash deploy-opentenbase.sh --yes \
+sudo bash opentenbase.sh install --yes \
     --cluster-name mycluster \
     --ssh-password mypass123 \
     --gtm-ip 192.168.1.10
@@ -94,11 +97,14 @@ opentenbase_ctl status -c /tmp/otb_config.ini
 ### 卸载
 
 ```bash
-# 交互式卸载（删除前会逐一确认）
+# CDN 加速（推荐）
+curl -sSL https://repo.blackevil217.com/scripts/uninstall.sh | sudo bash
+
+# GitHub 直连（备用）
 curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/uninstall.sh | sudo bash
 
 # 完全卸载（包括数据和日志，无需确认）
-curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/uninstall.sh | sudo bash -s -- --purge --yes
+curl -sSL https://repo.blackevil217.com/scripts/uninstall.sh | sudo bash -s -- --purge --yes
 ```
 
 ---
@@ -107,10 +113,10 @@ curl -sSL https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/Op
 
 安装脚本会自动检测并使用最快的可用镜像：
 
-1. **Cloudflare CDN**（`repo.blackevil217.com/apt` 用于 APT，`repo.blackevil217.com/rpm` 用于 RPM）— 全球加速，永久免费
+1. **Cloudflare CDN**（`repo.blackevil217.com/scripts/` 用于脚本，`repo.blackevil217.com/apt` 用于 APT，`repo.blackevil217.com/rpm` 用于 RPM）— 全球加速，永久免费
 2. **GitHub Pages**（`cduestc-openatom-open-source-club.github.io/OpenTenBase-Packages/`）— 直接备用
 
-> **注意**：快速安装部分的 `curl` 命令从 `raw.githubusercontent.com` 下载脚本。执行后，脚本会自动将您的系统配置为使用 CDN 加速仓库。
+> **推荐**：使用 `https://repo.blackevil217.com/scripts/opentenbase.sh` CDN 路径下载脚本，速度更快更稳定。
 
 ### 国内加速实测（2026-06-02）
 

--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -816,18 +816,26 @@ echo -e "    Datanode:    ${CYAN}${DN_IP}${NC}"
 echo ""
 echo -e "  ${BOLD}配置文件:${NC} ${CYAN}${CONFIG_FILE}${NC}"
 echo ""
-echo -e "  ${BOLD}常用命令:${NC}"
+echo -e "  ${BOLD}日常运维:${NC} ${GREEN}以下工具已随包安装到本机，日常运维直接用这些短命令即可，无需再 curl 长脚本${NC}"
 if [[ "$USE_PGXC_CTL" == "true" ]]; then
+echo -e "    运维工具: ${CYAN}pgxc_ctl${NC}  （v${OTB_VERSION} 集群管理器，需先 export PATH）"
 echo -e "    ${CYAN}export PATH=${INSTALL_DIR}/bin:\$PATH${NC}"
-echo -e "    ${CYAN}pgxc_ctl monitor all${NC}    # 查看状态"
-echo -e "    ${CYAN}pgxc_ctl stop all${NC}       # 停止集群"
-echo -e "    ${CYAN}pgxc_ctl start all${NC}      # 启动集群"
+echo -e "    ${CYAN}pgxc_ctl monitor all${NC}      # 查看集群状态"
+echo -e "    ${CYAN}pgxc_ctl start all${NC}        # 启动集群"
+echo -e "    ${CYAN}pgxc_ctl stop all${NC}         # 停止集群"
 else
-echo -e "    ${CYAN}opentenbase_ctl status${NC}   # 查看状态"
-echo -e "    ${CYAN}opentenbase_ctl stop${NC}     # 停止集群"
-echo -e "    ${CYAN}opentenbase_ctl start${NC}    # 启动集群"
+echo -e "    运维工具: ${CYAN}opentenbase_ctl${NC}  （v${OTB_VERSION} 集群管理器，全生命周期：install/start/stop/status/expand/shrink/delete）"
+echo -e "    ${CYAN}opentenbase_ctl status${NC}              # 查看集群状态"
+echo -e "    ${CYAN}opentenbase_ctl start${NC}               # 启动集群"
+echo -e "    ${CYAN}opentenbase_ctl stop${NC}                # 停止集群"
+echo -e "    ${CYAN}opentenbase_ctl expand -c $CONFIG_FILE${NC}   # 扩容节点"
 echo -e "    ${CYAN}opentenbase_ctl delete -c $CONFIG_FILE${NC}   # 删除集群"
 fi
+echo ""
+echo -e "  ${BOLD}一键脚本（仅装/卸/自检时用，日常运维不用）:${NC}"
+echo -e "    ${CYAN}opentenbase.sh status${NC}    # 快速自检（端口/进程/连接）"
+echo -e "    ${CYAN}opentenbase.sh test${NC}      # 完整验证（建表/读写/分片）"
+echo -e "    ${CYAN}opentenbase.sh uninstall${NC} # 卸载"
 echo ""
 echo -e "  ${BOLD}连接数据库:${NC}"
 if [[ "$USE_PGXC_CTL" == "true" ]]; then
@@ -877,6 +885,10 @@ OpenTenBase 一键管理脚本
   switch       切换版本
   status       查看集群状态
   test         验证测试（创建分布式表、读写测试）
+
+日常运维（集群装好后，用随包安装的本地工具，无需再 curl）:
+  v5.0  → opentenbase_ctl {status|start|stop|expand|shrink|delete}
+  v2.5/v2.6 → pgxc_ctl {monitor|start|stop} all   （需先 export PATH=安装目录/bin）
 
 选项:
   install:


### PR DESCRIPTION
## Problem

The CDN (repo.blackevil217.com) only hosts APT/RPM repositories but NOT installation scripts. Users downloading scripts from GitHub raw often experience slow speeds or timeouts, especially in China.

## Solution

1. **Update GitHub Pages workflow** to copy scripts to the deployment directory
2. **Update README** to recommend CDN path for script downloads

## Changes

### Workflow (.github/workflows/deploy-repo.yml)
- Copy 6 scripts to `repo/scripts/` during deployment
- Fix script path from `scripts/build-repo.sh` to `scripts/tools/build-repo.sh`

### Documentation (README.md & README_zh.md)
- Recommend CDN path: `https://repo.blackevil217.com/scripts/opentenbase.sh`
- Keep GitHub raw as fallback option
- Update mirror acceleration section

## Benefits

After this change:
- Scripts accessible via CDN: `https://repo.blackevil217.com/scripts/opentenbase.sh`
- Faster downloads globally via Cloudflare CDN
- Better user experience, especially in regions with slow GitHub access

## Testing

Once merged, the deploy-repo workflow will run automatically. After completion:
- `curl -sSL https://repo.blackevil217.com/scripts/opentenbase.sh` should work
- All 6 scripts will be available in `/scripts/` directory on CDN

Test command for the target server:
```bash
curl -sSL https://repo.blackevil217.com/scripts/opentenbase.sh | sudo bash -s -- install --yes
```