### PR TITLE
Fix repo config check + pass version param to setup scripts

### DIFF
--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -355,18 +355,18 @@ else
         log_info "安装 sshpass..."
         apt-get install -y sshpass >/dev/null 2>&1 || true
 
-        # 配置仓库
-        if ! apt-cache show opentenbase >/dev/null 2>&1; then
+        # 配置仓库（用 sources.list 文件存在性检查，避免包名匹配干扰）
+        if [ ! -f /etc/apt/sources.list.d/opentenbase.list ]; then
             log_info "配置 OpenTenBase APT 仓库..."
             # Use CDN for faster global access, fallback to GitHub raw
             CDN_URL="https://repo.blackevil217.com/scripts/setup-apt.sh"
             GITHUB_URL="https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-apt.sh"
 
-            if curl -sSL --connect-timeout 5 --max-time 15 "$CDN_URL" | bash; then
-                log_ok "APT repository configured via CDN"
+            if curl -sSL --connect-timeout 5 --max-time 60 "$CDN_URL" | bash -s -- --version "$OTB_VERSION"; then
+                log_ok "APT repository configured via CDN (version $OTB_VERSION)"
             else
                 log_warn "CDN unavailable, falling back to GitHub..."
-                curl -sSL "$GITHUB_URL" | bash || {
+                curl -sSL "$GITHUB_URL" | bash -s -- --version "$OTB_VERSION" || {
                     log_warn "自动配置仓库失败，尝试直接安装..."
                 }
             fi
@@ -390,18 +390,20 @@ else
         log_info "安装 sshpass..."
         $YUM install -y sshpass >/dev/null 2>&1 || true
 
-        # 配置仓库
-        if ! $YUM list available opentenbase >/dev/null 2>&1; then
+        # 配置仓库（用 repo 文件存在性检查，而非包名匹配——后者会被
+        # 系统自带仓库里大小写不同的同名包干扰，例如 OpenCloudOS 的 EPOL
+        # 里有 OpenTenBase，会让 dnf list available opentenbase 误判为已可用）
+        if [ ! -f /etc/yum.repos.d/opentenbase.repo ]; then
             log_info "配置 OpenTenBase RPM 仓库..."
             # Use CDN for faster global access, fallback to GitHub raw
             CDN_URL="https://repo.blackevil217.com/scripts/setup-rpm.sh"
             GITHUB_URL="https://raw.githubusercontent.com/CDUESTC-OpenAtom-Open-Source-Club/OpenTenBase-Packages/main/scripts/setup-rpm.sh"
 
-            if curl -sSL --connect-timeout 5 --max-time 15 "$CDN_URL" | bash; then
-                log_ok "RPM repository configured via CDN"
+            if curl -sSL --connect-timeout 5 --max-time 60 "$CDN_URL" | bash -s -- --version "$OTB_VERSION"; then
+                log_ok "RPM repository configured via CDN (version $OTB_VERSION)"
             else
                 log_warn "CDN unavailable, falling back to GitHub..."
-                curl -sSL "$GITHUB_URL" | bash || {
+                curl -sSL "$GITHUB_URL" | bash -s -- --version "$OTB_VERSION" || {
                     log_warn "自动配置仓库失败，尝试直接安装..."
                 }
             fi


### PR DESCRIPTION
Fixes three bugs blocking multi-version install on OpenCloudOS/RHEL.

## Root cause
On OpenCloudOS, the EPOL repo ships a differently-cased package `OpenTenBase`. The check `dnf list available opentenbase` is case-insensitive, so it matched EPOL's package and **falsely skipped our repo setup** on fresh installs → `dnf install opentenbase` failed.

## Fixes
1. **Repo check**: replace package-name availability check with repo-file existence check (`/etc/yum.repos.d/opentenbase.repo` / `/etc/apt/sources.list.d/opentenbase.list`) — reliable and idempotent.
2. **Version param**: forward `--version $OTB_VERSION` to setup-apt.sh/setup-rpm.sh on both CDN and GitHub paths.
3. **Timeout**: raise curl `--max-time` 15s → 60s (setup scripts run dnf makecache, ~20MB metadata).

## Testing
Smoke tested manually: setup-rpm.sh configures repo correctly. Will run full smoke test after merge.