### PR TITLE
Fallback to rpm --nodeps when dnf rejects RHPG symbol deps

### DIFF
--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -411,11 +411,27 @@ else
 
         # 安装
         log_info "安装 opentenbase..."
-        $YUM install -y opentenbase 2>/dev/null || \
-        $YUM install -y --nogpgcheck opentenbase 2>/dev/null || {
-            log_error "$YUM 安装失败，请手动运行: $YUM install opentenbase"
-            exit 1
-        }
+        if ! $YUM install -y opentenbase 2>/dev/null && \
+           ! $YUM install -y --nogpgcheck --nobest opentenbase 2>/dev/null; then
+            # 兜底：某些发行版（如 OpenCloudOS/RHEL）缺少 RPM 构建时记录的
+            # Red Hat 特有符号依赖（libpq.so.5(RHPG_10) 等），导致 dnf 拒绝安装。
+            # 但 opentenbase 包自带完整 libpq（在 INSTALL_DIR/lib/），运行时不依赖
+            # 系统 libpq，所以用 rpm --nodeps 强制安装是安全的。
+            log_warn "$YUM 安装因依赖符号失败，降级用 rpm --nodeps 强制安装..."
+            rm -f /tmp/opentenbase-*.rpm 2>/dev/null
+            ( cd /tmp && $YUM download opentenbase >/dev/null 2>&1 )
+            OTB_PKG_RPM=$(ls -1t /tmp/opentenbase-*.rpm 2>/dev/null | head -1)
+            if [ -n "$OTB_PKG_RPM" ] && [ -f "$OTB_PKG_RPM" ]; then
+                rpm -ivh --nodeps "$OTB_PKG_RPM" || {
+                    log_error "rpm 强制安装失败: $OTB_PKG_RPM"
+                    exit 1
+                }
+                log_ok "已通过 rpm --nodeps 安装 (跳过 RHPG 符号依赖)"
+            else
+                log_error "$YUM 安装失败且无法下载包，请手动运行: $YUM install opentenbase"
+                exit 1
+            fi
+        fi
     else
         log_error "不支持的系统（无 apt/dnf/yum）"
         exit 1


### PR DESCRIPTION
Fixes install failure on OpenCloudOS / any distro without RHEL's libpq.

## Problem
The opentenbase RPM was built against RHEL's libpq, so its metadata declares Red Hat-specific symbol-version Requires:
```
nothing provides libpq.so.5(RHPG_10)(64bit)
nothing provides libpq.so.5(RHPG_9.6)(64bit)
```
OpenCloudOS (and similar) ship no such symbols → `dnf install opentenbase` is rejected, and `--nobest --skip-broken` just skips the package entirely.

## Why --nodeps is safe
The package **bundles its own complete libpq** at `/usr/lib/opentenbase/<ver>/lib/libpq.so.5`. At runtime OpenTenBase uses this bundled libpq (via LD_LIBRARY_PATH / rpath), NOT the system one. Verified on the target server:
```
rpm -ivh --nodeps opentenbase-5.0-*.rpm   # succeeds
opentenbase_ctl --help                      # works
```

## Fix
New fallback chain in opentenbase.sh RPM install:
1. `dnf install -y opentenbase`
2. `dnf install -y --nogpgcheck --nobest opentenbase`
3. `dnf download` + `rpm -ivh --nodeps`

## Note
The cleaner long-term fix is to drop the spurious RHPG symbol Requires from the RPM spec at build time — tracked separately. This PR is the install-side workaround so users on affected distros can install today.