### PR TITLE
Detect installed version reliably in status/test subcommands

### DIFF
--- a/scripts/opentenbase.sh
+++ b/scripts/opentenbase.sh
@@ -917,6 +917,29 @@ fi  # end of "if [[ "$OTB_COMMAND" == "install" ]]" 部署主体守卫
 # 新增功能函数（子命令实现）
 # ====================================================================
 
+# 检测实际安装的 OpenTenBase 版本（供 status/test 子命令用）
+# 优先级：rpm 查询 > /usr/lib/opentenbase 目录扫描 > 默认 5.0
+# 不能依赖 opentenbase-switch-version（可能未安装），否则会误判为 5.0。
+detect_installed_version() {
+    local ver=""
+    # 1) rpm 元包查询最可靠（version-release，取 release 前的 version）
+    if command -v rpm >/dev/null 2>&1; then
+        ver=$(rpm -q --qf '%{VERSION}' opentenbase 2>/dev/null | grep -E '^(5\.0|2\.6\.0|2\.5\.0)$' | head -1)
+    fi
+    # 2) 扫描安装目录（apt 系统或 nodeps 安装 rpm 查询不到时）
+    if [ -z "$ver" ]; then
+        for d in /usr/lib/opentenbase/5.0 /usr/lib/opentenbase/2.6.0 /usr/lib/opentenbase/2.5.0; do
+            if [ -x "$d/bin/postgres" ] || [ -x "$d/bin/pgxc_ctl" ] || [ -x "$d/bin/opentenbase_ctl" ]; then
+                ver=$(basename "$d")
+                break
+            fi
+        done
+    fi
+    # 3) 兜底
+    [ -n "$ver" ] || ver="5.0"
+    echo "$ver"
+}
+
 # 显示使用帮助
 show_usage() {
 	cat << EOF
@@ -972,7 +995,7 @@ show_cluster_status() {
 	log_step "检查 OpenTenBase 集群状态..."
 
 	# 检测当前版本
-	OTB_VERSION=$(opentenbase-switch-version 2>/dev/null | grep "current" | awk '{print $2}' || echo "5.0")
+	OTB_VERSION=$(detect_installed_version)
 	INSTALL_DIR="/usr/lib/opentenbase/${OTB_VERSION}"
 
 	# 检测使用的链路
@@ -1041,7 +1064,7 @@ run_verification_test() {
 	log_step "OpenTenBase 验证测试..."
 
 	# 检测当前版本和端口
-	OTB_VERSION=$(opentenbase-switch-version 2>/dev/null | grep "current" | awk '{print $2}' || echo "5.0")
+	OTB_VERSION=$(detect_installed_version)
 	USE_PGXC_CTL=false
 	[[ "$OTB_VERSION" =~ ^2\. ]] && USE_PGXC_CTL=true
 	CN_PORT=$([[ "$USE_PGXC_CTL" == "true" ]] && echo 5432 || echo 11003)


### PR DESCRIPTION
Fixes status/test misreporting a 2.6.0 cluster as v5.0.

## Problem
`status` and `test` detected the version via `opentenbase-switch-version`, which isn't always installed. It silently fell back to 5.0, so on a 2.6.0 cluster:
- reported `版本: 5.0 / opentenbase_ctl` (wrong)
- tested against port 11003 instead of 5432
- looked for opentenbase_ctl instead of pgxc_ctl

## Fix
New `detect_installed_version()`:
1. `rpm -q --qf '%{VERSION}' opentenbase` (most reliable)
2. scan `/usr/lib/opentenbase/<ver>/bin` for a real binary (apt / nodeps installs)
3. default 5.0

Used by both `show_cluster_status` and `run_verification_test`.