### PR TITLE
fix(ci): expand RPM ARM64 matrix to full coverage

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -248,10 +248,10 @@ jobs:
     needs: setup-matrix
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         include:
-          # v5.0 aarch64
+          # v5.0 aarch64 - full coverage (6 distros with ARM64 images)
           - version: '5.0'
             distro: 'openeuler-22.03'
             container: 'openeuler/openeuler:22.03'
@@ -259,9 +259,18 @@ jobs:
             distro: 'rockylinux-9'
             container: 'rockylinux:9'
           - version: '5.0'
+            distro: 'rockylinux-8'
+            container: 'rockylinux:8'
+          - version: '5.0'
             distro: 'almalinux-9'
             container: 'almalinux:9'
-          # v2.6.0 aarch64
+          - version: '5.0'
+            distro: 'almalinux-8'
+            container: 'almalinux:8'
+          - version: '5.0'
+            distro: 'fedora-40'
+            container: 'quay.io/fedora/fedora:40'
+          # v2.6.0 aarch64 - full coverage
           - version: '2.6.0'
             distro: 'openeuler-22.03'
             container: 'openeuler/openeuler:22.03'
@@ -269,9 +278,18 @@ jobs:
             distro: 'rockylinux-9'
             container: 'rockylinux:9'
           - version: '2.6.0'
+            distro: 'rockylinux-8'
+            container: 'rockylinux:8'
+          - version: '2.6.0'
             distro: 'almalinux-9'
             container: 'almalinux:9'
-          # v2.5.0 aarch64
+          - version: '2.6.0'
+            distro: 'almalinux-8'
+            container: 'almalinux:8'
+          - version: '2.6.0'
+            distro: 'fedora-40'
+            container: 'quay.io/fedora/fedora:40'
+          # v2.5.0 aarch64 - full coverage
           - version: '2.5.0'
             distro: 'openeuler-22.03'
             container: 'openeuler/openeuler:22.03'
@@ -279,8 +297,17 @@ jobs:
             distro: 'rockylinux-9'
             container: 'rockylinux:9'
           - version: '2.5.0'
+            distro: 'rockylinux-8'
+            container: 'rockylinux:8'
+          - version: '2.5.0'
             distro: 'almalinux-9'
             container: 'almalinux:9'
+          - version: '2.5.0'
+            distro: 'almalinux-8'
+            container: 'almalinux:8'
+          - version: '2.5.0'
+            distro: 'fedora-40'
+            container: 'quay.io/fedora/fedora:40'
 
     name: ${{ matrix.distro }}-${{ matrix.version }}-aarch64
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary

This PR expands the RPM ARM64 build matrix to improve coverage from 38% to 75%.

### Changes

1. **Add rockylinux-8** for all versions (v5.0, v2.6.0, v2.5.0)
2. **Add almalinux-8** for all versions
3. **Add fedora-40** for all versions  
4. **Increase max-parallel** from 3 to 4

### Coverage Comparison

| Platform | Before | After |
|----------|--------|-------|
| x86_64 | 24/24 (100%) | 24/24 (100%) |
| aarch64 | 9/24 (38%) | **18/24 (75%)** |
| **Total RPM** | 33/48 | **42/48 (88%)** |

### Excluded Distributions

- `centos-stream-8/9`: No official ARM64 container images available

### Test Plan

Merge this PR and trigger a manual build-rpm workflow to verify ARM64 builds succeed on all new platforms.

## Related

- Follow-up to PR #57 which fixed DEB ARM64 builds
- Addresses ARCHITECTURE.md issue: "ARM64 CI 覆盖不到一半"