### PR TITLE
fix: correct cron expression format

### DIFF
--- a/.github/workflows/build-libpqxx.yml
+++ b/.github/workflows/build-libpqxx.yml
@@ -7,7 +7,7 @@ on:
       - 'deps/**'
   schedule:
     # Monthly rebuild to catch any security updates
-    - cron: '0 2 1 *'
+    - cron: '0 2 1 * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
Fix cron expression from 4 fields to 5 fields (standard format: minute hour day month weekday)