### PR TITLE
fix: correct install file paths for libpqxx packages

### DIFF
--- a/deps/libpqxx/debian/libpqxx-7.9-dev.install
+++ b/deps/libpqxx/debian/libpqxx-7.9-dev.install
@@ -1,5 +1,3 @@
 usr/include/pqxx/
 usr/lib/*/libpqxx.so
-usr/lib/*/libpqxx.a
 usr/lib/*/cmake/libpqxx/
-usr/share/doc/libpqxx/

--- a/deps/libpqxx/debian/libpqxx-7.9.install
+++ b/deps/libpqxx/debian/libpqxx-7.9.install
@@ -1,2 +1,2 @@
-usr/lib/*/libpqxx-*.so.*
-usr/share/doc/libpqxx/LICENSE
+usr/lib/*/libpqxx.so.*
+usr/share/doc/libpqxx/


### PR DESCRIPTION
Fix paths in debian/*.install files to match actual cmake install locations