### PR TITLE
fix: correct libpqxx install paths

### DIFF
--- a/deps/libpqxx/debian/libpqxx-7.9-dev.install
+++ b/deps/libpqxx/debian/libpqxx-7.9-dev.install
@@ -1,3 +1,4 @@
 usr/include/pqxx/
 usr/lib/*/libpqxx.so
 usr/lib/*/cmake/libpqxx/
+usr/lib/*/pkgconfig/libpqxx.pc

--- a/deps/libpqxx/debian/libpqxx-7.9.install
+++ b/deps/libpqxx/debian/libpqxx-7.9.install
@@ -1,2 +1,1 @@
-usr/lib/*/libpqxx.so.*
-usr/share/doc/libpqxx/
+usr/lib/*/libpqxx-7.9.so

--- a/deps/libpqxx/debian/libpqxx-doc.install
+++ b/deps/libpqxx/debian/libpqxx-doc.install
@@ -1,0 +1,1 @@
+usr/share/doc/libpqxx/


### PR DESCRIPTION
libpqxx installs shared library as libpqxx-7.9.so, not libpqxx.so.*. Fix install file globs to match actual cmake output.