### PR TITLE
fix: add debian/not-installed to ignore doc files

### DIFF
--- a/deps/libpqxx/debian/not-installed
+++ b/deps/libpqxx/debian/not-installed
@@ -1,0 +1,2 @@
+# Documentation files - not needed for runtime or development
+usr/share/doc/libpqxx/*.md


### PR DESCRIPTION
dh_missing was failing because doc files were installed but not assigned to any package. Add not-installed file to suppress the warning.